### PR TITLE
Check if method name is not undefined

### DIFF
--- a/src/transformAST.ts
+++ b/src/transformAST.ts
@@ -42,7 +42,7 @@ function getType(prop: ts.PropertySignature): MemberType {
 }
 
 function getMethods(checker: ts.TypeChecker, type: ts.Type, classDeclaratinNode: ts.ClassDeclaration) {
-    return classDeclaratinNode.members
+    return classDeclaratinNode.members.filter(x => x.name !== undefined)
         .map(i => ({ name: i.name.getText() }));
 }
 


### PR DESCRIPTION
Currently this component:

```js
import * as React from 'react';

export interface IAppMenuProps {
  /** Menu items */
  menu: any;
}

export interface IAppMenuState {
  menu: any;
}

/**
 * App Menu Component
 * 
 * Renders a menu in horizontal mode
 */
export class AppMenu extends React.Component<IAppMenuProps, IAppMenuState> {
  constructor(props, context) {
    super(props, context);
    this.state = {
      menu: this.props.menu
    };

    this.handleClick  = this.handleClick.bind(this);
  }

  componentWillReceiveProps(newProps: IAppMenuProps) {

  }

  handleClick( info ) {

  }

  render() {
    return (
      <div onClick={this.handleClick}>
        test
      </div>
    );
  };
}
```

Returns a `cannot getText() of undefined` 
Methods have two `name: undefined` objects at the beginning and at the end
 