### PR TITLE
Checked props to avoid getText() and kind issues

### DIFF
--- a/src/__tests__/data/InlineConst.tsx
+++ b/src/__tests__/data/InlineConst.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+/**
+ * A repro props interface
+ */
+export interface IReproProps {
+    /** A foo property */
+    foo: any;
+}
+
+/**
+ * My InlineConst Component
+ */
+export class MyComponent extends React.Component<IReproProps, {}> {
+    render() {
+        const repeat = func => setInterval(func, 16);
+
+        return (
+            <div>test</div>
+        );
+    }
+}

--- a/src/__tests__/data/UnassignedLet.tsx
+++ b/src/__tests__/data/UnassignedLet.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+/**
+ * A repro props interface
+ */
+export interface IReproProps {
+    /** A foo property */
+    foo: any;
+}
+
+/**
+ * My Repro Component
+ */
+export class Repro extends React.Component<IReproProps, {}> {
+    constructor(props) {
+        super(props);
+    }
+
+    private repro() {
+        let repro;
+        repro = 1;
+    }
+
+    public render() {
+        return(<div/>);
+    }
+}

--- a/src/__tests__/getFileDocumentation.spec.ts
+++ b/src/__tests__/getFileDocumentation.spec.ts
@@ -299,4 +299,45 @@ describe('getFileDocumentation', () => {
         assert.ok(result.components);
     })
 
+    it('Should parse inline function ', () => {
+        const fileName = path.join(__dirname, '../../src/__tests__/data/InlineConst.tsx'); // it's running in ./temp
+        const result = getFileDocumentation(fileName);
+
+        assert.ok(result.components);
+        assert.equal(1, result.components.length);
+
+        const c = result.components[0];
+        assert.equal('MyComponent', c.name);
+        assert.equal('My InlineConst Component', c.comment);
+        assert.equal('Component', c.extends);
+        assert.isNotNull(c.propInterface);
+
+        const i = c.propInterface;
+        assert.equal('IReproProps', i.name);
+        assert.equal('A repro props interface', i.comment);
+        assert.equal(1, i.members.length);
+        assert.equal('foo', i.members[0].name);
+        assert.equal('A foo property', i.members[0].comment);
+    }); 
+
+    it('Should parse component with unassigned let', () => {
+        const fileName = path.join(__dirname, '../../src/__tests__/data/UnassignedLet.tsx'); // it's running in ./temp
+        const result = getFileDocumentation(fileName);
+
+        assert.ok(result.components);
+        assert.equal(1, result.components.length);
+
+        const c = result.components[0];
+        assert.equal('Repro', c.name);
+        assert.equal('My Repro Component', c.comment);
+        assert.equal('Component', c.extends);
+        assert.isNotNull(c.propInterface);
+
+        const i = c.propInterface;
+        assert.equal('IReproProps', i.name);
+        assert.equal('A repro props interface', i.comment);
+        assert.equal(1, i.members.length);
+        assert.equal('foo', i.members[0].name);
+        assert.equal('A foo property', i.members[0].comment);
+    }); 
 });

--- a/src/transformAST.ts
+++ b/src/transformAST.ts
@@ -119,7 +119,10 @@ export function transformAST(sourceFile: ts.SourceFile, checker: ts.TypeChecker)
             const initializerFlags = initializerType.flags;
             let arrowFunctionParams: string[] = [];
             let callExpressionArguments: string[] = [];
-            if (d.initializer.kind === ts.SyntaxKind.ArrowFunction) {
+            
+            if (!d.initializer) {
+                kind = 'unknown';
+            } else if (d.initializer.kind === ts.SyntaxKind.ArrowFunction) {
                 const arrowFunc = d.initializer as ts.ArrowFunction; 
                 if (arrowFunc.parameters) {
                     arrowFunctionParams = arrowFunc


### PR DESCRIPTION
helps checks when using:

```javascript
class MyComponent extends React.Component<{}, {}> {
 const myFunc = props => console.log('test');
}
```

By checking type and initializer