### PR TITLE
Add support for JsDoc tags (fix issue #28)

### DIFF
--- a/src/__tests__/data/transformAST.tsx
+++ b/src/__tests__/data/transformAST.tsx
@@ -8,7 +8,11 @@ export const exportedVar = 10;
 /** unexportedVarFunction comment */
 const unexportedVarFunction = (param1: string): number => 0
 ;
-/** exportedVarFunction comment */
+/** exportedVarFunction comment
+ *
+ * @tag1
+ * @tag2 partA partB partC
+ */
 export const exportedVarFunction = (param1: number, param2: string): string => "";
 
 function unexportedFunction(param1: number): string {
@@ -22,8 +26,21 @@ function exportedFunction(param1: string, param2: number): number {
 interface UnexportedInterface {
     /** prop1 comment */
     prop1: string;
+
+    /**
+     * prop2 comment
+     * @tag1
+     * @tag2 partA partB partC
+     */
+    prop2?: string;
 }
 
+/**
+ * Interface comment
+ * 
+ * @tag1
+ * @tag2 partA partB partC
+ */
 export interface ExportedInterface {
     /** prop1 comment */
     prop1: string;
@@ -46,7 +63,10 @@ class UnexportedClass extends OurBaseClass<ExportedInterface, {}> {
     }
 }
 
-/** ExportedClass comment */
+/** ExportedClass comment
+ * @tag1 partA partB
+ * @tag2
+ */
 export class ExportedClass {
     method1(): string {
         return "";
@@ -73,7 +93,10 @@ export const exportedExternalHoc1 = externalHoc(ExportedClass);
 /** exportedExternalHoc2 comment */
 export const exportedExternalHoc2 = externalHoc(exportedFunction);
 
-/** exported intersection type */
+/** exported intersection type
+ * @tag1 partA partB
+ * @tag2
+ */
 export type ExportedType1 = React.HTMLAttributes<HTMLImageElement> & { 
     /** the first property */
     prop1: "value1" | "value2";

--- a/src/__tests__/data/transformAST_external.ts
+++ b/src/__tests__/data/transformAST_external.ts
@@ -2,7 +2,9 @@ export interface ExternalInterfaceBase {
     prop1ExternalInterfaceBase: string;
 }
 
-/** ExternalInterface comment */
+/** ExternalInterface comment
+ * @tag
+ */
 export interface ExternalInterface extends ExternalInterfaceBase {
     /** prop1 comment */
     prop1OnExternalInterface: string;

--- a/src/__tests__/getFileDocumentation.spec.ts
+++ b/src/__tests__/getFileDocumentation.spec.ts
@@ -272,7 +272,7 @@ describe('getFileDocumentation', () => {
         assert.isNotNull(r1.propInterface);
         const p1 = r1.propInterface;
         assert.equal(p1.name, 'Props');
-        assert.equal(p1.comment, 'Props comment ');
+        assert.equal(p1.comment, 'Props comment');
         assert.equal(p1.members.length, 2);
         assert.equal(p1.members[0].name, 'isFlippedX');
         assert.equal(p1.members[0].comment, 'whether the image is flipped horizontally');

--- a/src/__tests__/transformAST.spec.ts
+++ b/src/__tests__/transformAST.spec.ts
@@ -44,7 +44,7 @@ describe('transformAST', () => {
         assert.equal(r4.name, 'exportedVarFunction');
         assert.equal(r4.exported, true);
         assert.equal(r4.kind, 'arrowFunction');
-        assert.equal(r4.comment, 'exportedVarFunction comment');
+        assert.equal(r4.comment, 'exportedVarFunction comment\n@tag1\n@tag2 partA partB partC');
         assert.equal(r4.arrowFunctionType, 'string');
         assert.deepEqual(r4.arrowFunctionParams, ['number', 'string']);
 
@@ -98,10 +98,18 @@ describe('transformAST', () => {
                 'isOwn': true,
                 'comment': 'prop1 comment',
                 'values': [],
+            }, {
+                'name': 'prop2',
+                'type': 'string',
+                'isRequired': false,
+                'isOwn': true,
+                'comment': 'prop2 comment\n@tag1\n@tag2 partA partB partC',
+                'values': [],
             }]);
 
         const r2 = result[1];
         assert.equal(r2.name, 'ExportedInterface');
+        assert.equal(r2.comment, 'Interface comment\n@tag1\n@tag2 partA partB partC');
         assert.equal(r2.exported, true);
         assert.deepEqual(r2.properties, [{
                 'name': 'prop1',
@@ -147,6 +155,7 @@ describe('transformAST', () => {
         const r4 = result[3];
         assert.equal(r4.name, 'ExternalInterface');
         assert.equal(r4.exported, true);
+        assert.equal(r4.comment, 'ExternalInterface comment\n@tag');
     });
 
     it('should provide data about classes', () => {        
@@ -161,7 +170,7 @@ describe('transformAST', () => {
         const r2 = result[2];
         assert.equal(r2.name, 'ExportedClass');
         assert.equal(r2.exported, true);
-        assert.equal(r2.comment, 'ExportedClass comment');
+        assert.equal(r2.comment, 'ExportedClass comment\n@tag1 partA partB\n@tag2');
         assert.deepEqual(r2.methods, [{name: 'method1'}, {name: 'method2'}]);
 
         const r4 = result[3];
@@ -175,6 +184,8 @@ describe('transformAST', () => {
         assert.equal(target.types.length, 1);
         const t1 = target.types[0];
         assert.equal(t1.name, 'ExportedType1');
+        assert.equal(t1.comment, 'exported intersection type\n@tag1 partA partB\n@tag2');
+
         // because ExportedType1 inherites from built in type and can 
         // change over time we don't use exact number here
         assert.isTrue(t1.properties.length > 200);

--- a/src/printUtils.ts
+++ b/src/printUtils.ts
@@ -77,6 +77,11 @@ export function simplePrint(checker: ts.TypeChecker, node: ts.Node, indent = 0) 
         if (comments.length > 0) {
             info.push(prefix + 'comment: \'' + comments.map(i => i.text).join('; ') + '\'');
         }
+        const jsdoctags = s.getJsDocTags();
+        if (jsdoctags.length > 0) {
+            info.push(prefix + 'jsdoctags: \'' +
+                jsdoctags.map(i => `@${i.name} ${i.text}`).join('; ') + '\'');
+        }
     }
 
     if (node.kind === ts.SyntaxKind.FunctionDeclaration) {


### PR DESCRIPTION
The TypeScript compiler splits JsDoc comments into two, and react-docgen-typescript was only pulling comment data from one of the two places.  This PR rebuilds the full comment from both parts.

(Pulling the comment formation logic out into a helper method also has the effect of providing  consistent handling both for null/undefined symbols when extracting comments and for whitespace-trimming.)
