### PR TITLE
support default props via defaultProps or JSDoc

### DIFF
--- a/src/__tests__/data/ComponentWithDefaultProps.tsx
+++ b/src/__tests__/data/ComponentWithDefaultProps.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+/** IComponentWithDefaultPropsProps props */
+export interface IComponentWithDefaultPropsProps {
+  /**
+   * sample with default value
+   * @default hello
+   */
+  sampleDefaultFromJSDoc: 'hello' | 'goodbye';
+  /** sampleTrue description */
+  sampleTrue?: boolean;
+  /** sampleFalse description */
+  sampleFalse?: boolean;
+  /** sampleString description */
+  sampleString?: string;
+  /** sampleObject description */
+  sampleObject?: { [key: string]: any; };
+  /** sampleNull description */
+  sampleNull?: null;
+  /** sampleUndefined description */
+  sampleUndefined?: any;
+}
+
+/** ComponentWithDefaultProps description */
+export class ComponentWithDefaultProps extends React.Component<IComponentWithDefaultPropsProps, {}> {
+  static defaultProps: Partial<IComponentWithDefaultPropsProps> = {
+    sampleTrue: true,
+    sampleFalse: false,
+    sampleString: 'hello',
+    sampleObject: { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
+    sampleNull: null,
+    sampleUndefined: undefined
+  }
+
+  render() {
+    return (
+      <div>test</div>
+    );
+  }
+}

--- a/src/__tests__/data/StatelessWithDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithDefaultProps.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export interface StatelessWithDefaultPropsProps {
+  /** sampleJSDoc description
+   * @default test
+   */
+  sampleJSDoc?: string;
+  /** sampleProp description */
+  sampleProp?: string;
+}
+
+/** StatelessWithDefaultProps description */
+export const StatelessWithDefaultProps: React.StatelessComponent<StatelessWithDefaultPropsProps> = props =>
+  <div>test</div>;
+
+StatelessWithDefaultProps.defaultProps = {
+  sampleProp: 'test'
+};
+
+export default StatelessWithDefaultProps;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import { check } from "./testUtils";
 
 describe('parser', () => {
-    
+
     const children = { type: 'ReactNode', required: false, description: '', };
 
     it('should parse simple react class component', function() {
@@ -71,10 +71,10 @@ describe('parser', () => {
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
                 // HtmlAttributes
-                defaultChecked: { 
-                    type: 'boolean', 
-                    required: false, 
-                    description: '' 
+                defaultChecked: {
+                    type: 'boolean',
+                    required: false,
+                    description: ''
                 }
                 // ...
             }
@@ -98,7 +98,7 @@ describe('parser', () => {
                 prop2: { type: 'number' },
             },
             // TODO: this wasn't there before, i would guess that that's correct
-            test: {                
+            test: {
             }
         }, false);
     });
@@ -141,6 +141,21 @@ describe('parser', () => {
         });
     });
 
+    it('should parse react component with default props', function(){
+        check('ComponentWithDefaultProps', {
+            ComponentWithDefaultProps: {
+                children,
+                sampleDefaultFromJSDoc: { type: '"hello" | "goodbye"', required: true, defaultValue: "hello", description: 'sample with default value' },
+                sampleTrue: { type: "boolean", required: false, defaultValue: "true" },
+                sampleFalse: { type: "boolean", required: false, defaultValue: "false" },
+                sampleString: { type: "string", required: false, defaultValue: "hello" },
+                sampleObject: { type: "{ [key: string]: any; }", required: false, defaultValue: "{ a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } }" },
+                sampleNull: { type: "null", required: false, defaultValue: "null" },
+                sampleUndefined: { type: "any", required: false, defaultValue: "undefined" },
+            }
+        });
+    });
+
     it('should parse react PureComponent', function(){
         check('PureRow', {
             Row: {
@@ -178,5 +193,16 @@ describe('parser', () => {
                 myProp: { type: 'string' },
             }
         });
-    });    
+    });
+
+    it('should parse react stateless component with default props', function(){
+        check('StatelessWithDefaultProps', {
+            StatelessWithDefaultProps: {
+                children,
+                sampleJSDoc: { type: "string", required: false, defaultValue: "test" },
+                sampleProp: { type: "string", required: false, defaultValue: "hello" },
+            }
+        });
+    });
+
 });

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -14,6 +14,7 @@ export interface ExpectedProp {
     type: string;
     required?: boolean;
     description?: string;
+    defaultValue?: string;
 }
 
 export function check(component: string, expected: ExpectedComponents, exactProperties: boolean = true) {
@@ -24,9 +25,9 @@ export function check(component: string, expected: ExpectedComponents, exactProp
 
 export function checkComponent(actual: ComponentDoc[], expected: ExpectedComponents, exactProperties: boolean = true) {
     const expectedComponentNames = Object.getOwnPropertyNames(expected);
-    assert.equal(actual.length, expectedComponentNames.length, 
+    assert.equal(actual.length, expectedComponentNames.length,
         `The number of expected components is different - \r\n\expected: ${expectedComponentNames}, \r\n\actual: ${actual.map(i => i.displayName)}`);
-    
+
     const errors: string[] = [];
     for (const expectedComponentName of expectedComponentNames) {
         const expectedComponent = expected[expectedComponentName];
@@ -39,7 +40,7 @@ export function checkComponent(actual: ComponentDoc[], expected: ExpectedCompone
         const expectedPropNames = Object.getOwnPropertyNames(expectedComponent);
         const propNames = Object.getOwnPropertyNames(componentDoc.props);
         const compName = componentDoc.displayName;
-        
+
         if (componentDoc.description !== `${compName} description`) {
             errors.push(`${compName} description is different - expected: '${compName} description', actual: '${componentDoc.description}'`)
         }
@@ -47,7 +48,7 @@ export function checkComponent(actual: ComponentDoc[], expected: ExpectedCompone
         if (propNames.length !== expectedPropNames.length && exactProperties === true) {
             errors.push(`Properties for ${compName} are different - expected: ${expectedPropNames.length}, actual: ${propNames.length} (${JSON.stringify(expectedPropNames)}, ${JSON.stringify(propNames)})`);
         }
-        
+
         for (const expectedPropName of expectedPropNames) {
             const expectedProp = expectedComponent[expectedPropName];
             const prop = componentDoc.props[expectedPropName];
@@ -63,7 +64,11 @@ export function checkComponent(actual: ComponentDoc[], expected: ExpectedCompone
                 }
                 const expectedRequired = expectedProp.required === undefined ? true : expectedProp.required;
                 if (expectedRequired !== prop.required) {
-                   errors.push(`Property '${compName}.${expectedPropName}' required is different - expected: ${expectedRequired}, actual: ${prop.required}`); 
+                   errors.push(`Property '${compName}.${expectedPropName}' required is different - expected: ${expectedRequired}, actual: ${prop.required}`);
+                }
+                const expectedDefaultValue = expectedProp.defaultValue;
+                if (expectedDefaultValue && prop.defaultValue && expectedDefaultValue !== prop.defaultValue.value) {
+                    errors.push(`Property '${compName}.${expectedPropName}' defaultValue is different - expected: ${expectedDefaultValue}, actual: ${prop.defaultValue.value}`);
                 }
             }
         }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,15 +2,17 @@ import * as ts from 'typescript';
 import * as path from 'path';
 import * as fs from 'fs';
 
+export interface StringIndexedObject<T> {
+    [key: string]: T;
+}
+
 export interface ComponentDoc {
     displayName: string;
     description: string;
     props: Props;
 }
 
-export interface Props {
-    [key: string]: PropItem;
-}
+export interface Props extends StringIndexedObject<PropItem> { }
 
 export interface PropItem {
     required: boolean;
@@ -92,6 +94,18 @@ export function withCompilerOptions(compilerOptions: ts.CompilerOptions): FilePa
     };
 }
 
+interface JSDoc {
+    description: string;
+    fullComment: string;
+    tags: StringIndexedObject<string>;
+}
+
+const defaultJSDoc: JSDoc = {
+    fullComment: '',
+    tags: {},
+    description: ''
+};
+
 class Parser {
     private checker: ts.TypeChecker;
 
@@ -108,11 +122,12 @@ class Parser {
 
         if (propsType) {
             const componentName = computeComponentName(exp, source);
-            const props = this.getPropsInfo(propsType);
+            const defaultProps = this.extractDefaultPropsFromComponent(exp, source);
+            const props = this.getPropsInfo(propsType, defaultProps);
 
             return {
                 displayName: componentName,
-                description: this.findDocComment(exp),
+                description: this.findDocComment(exp).fullComment,
                 props: props
             };
         }
@@ -132,10 +147,10 @@ class Parser {
                 if (params.length === 0) {
                     continue;
                 }
-                // Maybe we could check return type instead, 
-                // but not sure if Element, ReactElement<T> are all possible values                
+                // Maybe we could check return type instead,
+                // but not sure if Element, ReactElement<T> are all possible values
                 const propsParam = params[0];
-                if (propsParam.name === 'props' || params.length === 1) {                    
+                if (propsParam.name === 'props' || params.length === 1) {
                     return propsParam;
                 }
             }
@@ -164,18 +179,18 @@ class Parser {
         return null;
     }
 
-    public getPropsInfo(propsObj: ts.Symbol): Props {
+    public getPropsInfo(propsObj: ts.Symbol, defaultProps: StringIndexedObject<string> = {}): Props {
         const propsType = this.checker.getTypeOfSymbolAtLocation(propsObj, propsObj.valueDeclaration);
         const propertiesOfProps = propsType.getProperties();
 
         const result: Props = {};
 
         propertiesOfProps.forEach(prop => {
-            const propName = prop.getName();            
+            const propName = prop.getName();
 
             // Find type of prop by looking in context of the props object itself.
             const propType = this.checker.getTypeOfSymbolAtLocation(prop, propsObj.valueDeclaration);
-            
+
             const propTypeString = this.checker.typeToString(propType);
 
             const isOptional = (prop.getFlags() & ts.SymbolFlags.Optional) !== 0;
@@ -183,22 +198,28 @@ class Parser {
 
             const jsDocComment = this.findDocComment(prop);
 
+            let defaultValue = null;
+
+            if (defaultProps[propName] !== undefined) {
+                defaultValue = { value: defaultProps[propName] };
+            } else if (jsDocComment.tags.default) {
+                defaultValue = { value: jsDocComment.tags.default };
+            }
+
             result[propName] = {
                 required: !isOptional,
                 type: { name: propTypeString },
-                description: jsDocComment,
-
-                // TODO
-                defaultValue: null
+                description: jsDocComment.fullComment,
+                defaultValue
             };
         });
 
         return result;
     }
 
-    findDocComment(symbol: ts.Symbol) {
+    findDocComment(symbol: ts.Symbol): JSDoc {
         const comment = this.getFullJsDocComment(symbol);
-        if (comment) {
+        if (comment.fullComment) {
             return comment;
         }
 
@@ -206,40 +227,124 @@ class Parser {
         const commentsOnRootSymbols = rootSymbols
             .filter(x => x !== symbol)
             .map(x => this.getFullJsDocComment(x))
-            .filter(x => !!x);
+            .filter(x => !!x.fullComment);
 
         if (commentsOnRootSymbols.length) {
             return commentsOnRootSymbols[0];
         }
 
-        return '';
+        return defaultJSDoc;
     }
 
     /**
      * Extracts a full JsDoc comment from a symbol, even
-     * thought TypeScript has broken down the JsDoc comment into plain
+     * though TypeScript has broken down the JsDoc comment into plain
      * text and JsDoc tags.
      */
-    getFullJsDocComment(symbol: ts.Symbol) {
+    getFullJsDocComment(symbol: ts.Symbol): JSDoc {
 
         // in some cases this can be undefined (Pick<Type, 'prop1'|'prop2'>)
         if (symbol.getDocumentationComment === undefined) {
-            return "";
+            return defaultJSDoc;
         }
 
         const mainComment = ts.displayPartsToString(symbol.getDocumentationComment());
 
         const tags = symbol.getJsDocTags() || [];
-        const tagComments = tags.map(t => {
-            let result = '@' + t.name;
-            if (t.text) {
-                result += ' ' + t.text;
-            }
-            return result;
-        });
 
-        return (mainComment + '\n' + tagComments.join('\n')).trim();
+        const tagComments: string[] = [];
+        const tagMap: StringIndexedObject<string> = {};
+
+        tags.forEach(tag => {
+            const trimmedText = (tag.text || '').trim();
+            const currentValue = tagMap[tag.name];
+            tagMap[tag.name] = currentValue ? currentValue + '\n' + trimmedText : trimmedText;
+
+            if (tag.name !== 'default') { tagComments.push(formatTag(tag)); }
+        })
+
+        return ({
+            fullComment: (mainComment + '\n' + tagComments.join('\n')).trim(),
+            tags: tagMap,
+            description: mainComment
+        });
     }
+
+    extractDefaultPropsFromComponent(symbol: ts.Symbol, source: ts.SourceFile) {
+        const possibleStatements = source.statements.filter(statement => this.checker.getSymbolAtLocation((statement as ts.ClassDeclaration).name) === symbol);
+        if (!possibleStatements.length) {
+            return {};
+        }
+        const statement = possibleStatements[0];
+        if (statementIsClassDeclaration(statement) && statement.members.length) {
+            const possibleDefaultProps = statement.members.filter(member => member.name && getPropertyName(member.name) === 'defaultProps');
+            if (!possibleDefaultProps.length) {
+                return {};
+            }
+            const defaultProps = possibleDefaultProps[0];
+            const { initializer } = (defaultProps as ts.PropertyDeclaration);
+            const { properties } = (initializer as ts.ObjectLiteralExpression);
+            const propMap = (properties as ts.NodeArray<ts.PropertyAssignment>).reduce((acc, property) => {
+                const literalValue = getLiteralValueFromPropertyAssignment(property);
+                if (typeof literalValue === 'string') {
+                    if (!property.name) { console.log(property); }
+                    acc[getPropertyName(property.name)] = getLiteralValueFromPropertyAssignment(property);
+                }
+                return acc;
+            }, {} as StringIndexedObject<string>)
+            return propMap;
+        }
+        return {};
+    }
+}
+
+function statementIsClassDeclaration (statement: ts.Statement): statement is ts.ClassDeclaration {
+    return !!(statement as ts.ClassDeclaration).members;
+}
+
+function getPropertyName(name: ts.PropertyName): string | null {
+    switch (name.kind) {
+        case ts.SyntaxKind.NumericLiteral:
+        case ts.SyntaxKind.StringLiteral:
+        case ts.SyntaxKind.Identifier:
+            return name.text;
+        case ts.SyntaxKind.ComputedPropertyName:
+            return name.getText();
+        default:
+            return null;
+    }
+}
+
+function getLiteralValueFromPropertyAssignment(property: ts.PropertyAssignment): string | null {
+    const { initializer } = property;
+    switch(initializer.kind) {
+        case ts.SyntaxKind.FalseKeyword:
+            return 'false';
+        case ts.SyntaxKind.TrueKeyword:
+            return 'true';
+        case ts.SyntaxKind.StringLiteral:
+            return (initializer as ts.StringLiteral).text.trim();
+        case ts.SyntaxKind.NumericLiteral:
+            return `${(initializer as ts.NumericLiteral).text}`;
+        case ts.SyntaxKind.NullKeyword:
+            return 'null';
+        case ts.SyntaxKind.Identifier:
+            // can potentially find other identifiers in the source and map those in the future
+            return (initializer as ts.Identifier).text === 'undefined' ? 'undefined' : null;
+        case ts.SyntaxKind.ObjectLiteralExpression:
+            // return the source text for an object literal
+            return (initializer as ts.ObjectLiteralExpression).getText();
+        default:
+            return null;
+    }
+}
+
+function formatTag (tag: ts.JSDocTagInfo) {
+    let result = '@' + tag.name;
+    if (tag.text) {
+        result += ' ' + tag.text;
+    }
+    return result;
 }
 
 function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -287,7 +287,6 @@ class Parser {
             const propMap = (properties as ts.NodeArray<ts.PropertyAssignment>).reduce((acc, property) => {
                 const literalValue = getLiteralValueFromPropertyAssignment(property);
                 if (typeof literalValue === 'string') {
-                    if (!property.name) { console.log(property); }
                     acc[getPropertyName(property.name)] = getLiteralValueFromPropertyAssignment(property);
                 }
                 return acc;


### PR DESCRIPTION
fixes #37 

i've extended the parser to get default values from `Component.defaultProps` or JSDoc (`@default`)

i've also added two tests for class & stateless components, let me know if there are any other cases I should get.

here's a screenshot from one of my projects with a, rather exhaustive and contrived, default value list:
<img width="517" alt="screen shot 2017-11-08 at 9 17 26 pm" src="https://user-images.githubusercontent.com/1226910/32586770-416e402e-c4ca-11e7-8f2c-1b98086391f6.png">

<img width="270" alt="screen shot 2017-11-08 at 9 16 16 pm" src="https://user-images.githubusercontent.com/1226910/32586749-22d344ac-c4ca-11e7-9c55-518ca0b02783.png">
