### PR TITLE
Filter properties by static or dynamic conditions

### DIFF
--- a/src/__tests__/buildFilter.ts
+++ b/src/__tests__/buildFilter.ts
@@ -1,0 +1,99 @@
+import { assert, expect } from 'chai';
+import { buildFilter } from '../buildFilter';
+import { ParserOptions, Props, PropItem } from '../parser';
+
+function createProp(name: string, required: boolean = false, defaultValue: any = undefined, 
+  description: string = '', type = {name: 'string'}): PropItem {
+  return {
+    name,
+    type,
+    required,
+    defaultValue,
+    description
+  }
+}
+
+describe('buildFilter', () => {
+
+  describe('default behaviour', () => {
+    it('should skip "children" property if no description is set', () => {
+      const prop1 = createProp('prop1', false, undefined, 'prop1 description');
+      const prop2 = createProp('prop2', false, undefined, 'prop2 description');
+      const children = createProp('children', false, undefined, '');
+      const opts: ParserOptions = {};
+      const filterFn = buildFilter(opts);
+      expect([prop1, prop2, children].filter((prop) => filterFn(prop, {name: prop.name}))).to.eql([prop1, prop2]);
+    });
+    it('should not skip "children" property if description is set', () => {
+      const prop1 = createProp('prop1', false, undefined, 'prop1 description');
+      const prop2 = createProp('prop2', false, undefined, 'prop2 description');
+      const children = createProp('children', false, undefined, 'children description');
+      const opts: ParserOptions = {};
+      const filterFn = buildFilter(opts);
+      expect([prop1, prop2, children].filter((prop) => filterFn(prop, {name: prop.name}))).to.eql([prop1, prop2, children]);
+    });
+  });
+
+  describe('static prop filter', () => {
+
+    describe('skipPropsWithName', () => {
+      it('should skip single prop by name', () => {
+        const prop1 = createProp('prop1', false, undefined, 'prop1 description');
+        const prop2 = createProp('prop2', false, undefined, 'prop2 description');
+        const opts: ParserOptions = {
+          propFilter: { skipPropsWithName: 'prop1' }
+        };
+        const filterFn = buildFilter(opts);
+        expect([prop1, prop2].filter((prop) => filterFn(prop, {name: prop.name}))).to.eql([prop2]);
+      });
+      it('should skip multiple props by name', () => {
+        const prop1 = createProp('prop1', false, undefined, 'prop1 description');
+        const prop2 = createProp('prop2', false, undefined, 'prop2 description');
+        const prop3 = createProp('prop3', false, undefined, 'prop3 description');
+        const opts: ParserOptions = {
+          propFilter: { skipPropsWithName: ['prop1', 'prop3'] }
+        };
+        const filterFn = buildFilter(opts);
+        expect([prop1, prop2, prop3].filter((prop) => filterFn(prop, {name: prop.name}))).to.eql([prop2]);
+      });
+    });
+
+    describe('skipPropsWithoutDoc', () => {
+      it('should skip children props with no documentation', () => {
+        const prop1 = createProp('prop1', false, undefined, 'prop1 description');
+        const prop2 = createProp('prop2', false, undefined, '');
+        const opts: ParserOptions = {
+          propFilter: { skipPropsWithoutDoc: true }
+        };
+        const filterFn = buildFilter(opts);
+        expect([prop1, prop2].filter((prop) => filterFn(prop, {name: prop.name}))).to.eql([prop1]);
+      });
+    });
+
+  });
+
+  describe('dynamic prop filter', () => {
+    it('should skip props based on dynamic filter rule', () => {
+      const prop1 = createProp('foo', false, undefined, 'foo description');
+      const prop2 = createProp('bar', false, undefined, 'bar description');
+      const prop3 = createProp('foobar', false, undefined, 'foobar description');
+      const opts: ParserOptions = {
+        propFilter: (prop, component) => prop.name.indexOf('foo') === -1
+      };
+      const filterFn = buildFilter(opts);
+      expect([prop1, prop2, prop3].filter((prop) => filterFn(prop, {name: prop.name}))).to.eql([prop2]);
+    });
+
+    it('should get be possible to filter by component name', () => {
+      const prop1 = createProp('foo', false, undefined, 'foo description');
+      const prop2 = createProp('bar', false, undefined, 'bar description');
+      const prop3 = createProp('foobar', false, undefined, 'foobar description');
+      const opts: ParserOptions = {
+        propFilter: (prop, component) => component.name.indexOf('BAR') === -1
+      };
+      const filterFn = buildFilter(opts);
+      expect([prop1, prop2, prop3].filter((prop) => filterFn(prop, { name: prop.name.toUpperCase() }))).to.eql([prop1]);
+    });
+  });
+
+});

--- a/src/__tests__/data/ColumnWithAnnotatedChildren.tsx
+++ b/src/__tests__/data/ColumnWithAnnotatedChildren.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+/**
+ * Column properties.
+ */
+export interface IColumnProps {
+    /** prop1 description */
+    prop1?: string;
+    /** prop2 description */
+    prop2: number;
+    /**
+     * prop3 description
+     */
+    prop3: () => void;
+    /** prop4 description */
+    prop4: 'option1' | 'option2' | "option3";
+
+    /** children description */
+    children?: React.ReactNode;
+}
+
+/**
+ * Column description
+ */
+export class Column extends React.Component<IColumnProps, {}> {
+    public static defaultProps: Partial<IColumnProps> = {
+        prop1: 'prop1'
+    };
+
+    render() {
+        const {prop1} = this.props;
+        return <div>{prop1}</div>;
+    }
+}
+
+export default Column;

--- a/src/__tests__/data/ColumnWithUndocumentedProps.tsx
+++ b/src/__tests__/data/ColumnWithUndocumentedProps.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+/**
+ * Column properties.
+ */
+export interface IColumnProps {
+    /** prop1 description */
+    prop1?: string;
+    /** prop2 description */
+    prop2: number;
+}
+
+/**
+ * Column description
+ */
+export class Column extends React.Component<IColumnProps, {}> {
+    public static defaultProps: Partial<IColumnProps> = {
+        prop1: 'prop1'
+    };
+
+    render() {
+        const {prop1} = this.props;
+        return <div>{prop1}</div>;
+    }
+}
+
+export default Column;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import { check } from "./testUtils";
-import { PropsFilter } from '../parser';
+import { PropFilter } from '../parser';
 
 describe('parser', () => {
 
@@ -287,7 +287,7 @@ describe('parser', () => {
     describe('Parser options', function() {
 
         describe('Property filtering', function() {
-            const propsFilter: PropsFilter = (prop, componentName) => prop.name && prop.description.length > 0
+            const propFilter: PropFilter = (prop, componentName) => prop.name && prop.description.length > 0
 
             it('should ignore any property that is not documented explicitly', function() {
                 check('Column', {
@@ -297,7 +297,7 @@ describe('parser', () => {
                         prop3: { type: '() => void'},
                         prop4: { type: '"option1" | "option2" | "option3"' },
                     }
-                }, true, null, { propsFilter });
+                }, true, null, { propFilter });
             });
 
             it('should not ignore any property that is documented explicitly', function() {
@@ -309,7 +309,7 @@ describe('parser', () => {
                         prop3: { type: '() => void'},
                         prop4: { type: '"option1" | "option2" | "option3"' }
                     }
-                }, true, null, { propsFilter });
+                }, true, null, { propFilter });
             });
 
         });

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -9,7 +9,6 @@ describe('parser', () => {
     it('should parse simple react class component', function() {
         check('Column', {
             Column: {
-                children,
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
                 prop3: { type: '() => void'},
@@ -21,7 +20,6 @@ describe('parser', () => {
     it('should parse simple react class component as default export', function() {
         check('ColumnWithDefaultExport', {
             Column: {
-                children,
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
                 prop3: { type: '() => void'},
@@ -33,7 +31,6 @@ describe('parser', () => {
     it('should parse simple react class component as default export only', function() {
         check('ColumnWithDefaultExportOnly', {
             ColumnWithDefaultExportOnly: {
-                children,
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
                 prop3: { type: '() => void'},
@@ -45,7 +42,6 @@ describe('parser', () => {
     it('should parse simple react class component as default anonymous export', function() {
         check('ColumnWithDefaultAnonymousExportOnly', {
             ColumnWithDefaultAnonymousExportOnly: {
-                children,
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
                 prop3: { type: '() => void'},
@@ -57,7 +53,6 @@ describe('parser', () => {
     it('should parse simple react class component with state', () => {
         check('AppMenu', {
             AppMenu: {
-                children,
                 menu: { type: 'any' },
             }
         });
@@ -67,7 +62,6 @@ describe('parser', () => {
         // we are not able to get correct descriptions for prop1,prop2
         check('ColumnWithPick', {
             Column: {
-                children,
                 prop1: { type: 'string', required: false, description: '' },
                 prop2: { type: 'number', description: '' },
                 propx: { type: 'number' },
@@ -78,11 +72,9 @@ describe('parser', () => {
     it('should parse HOCs', function() {
         check('ColumnHigherOrderComponent', {
             ColumnHigherOrderComponent1: {
-                children,
                 prop1: { type: 'string' },
             },
             ColumnHigherOrderComponent2: {
-                children,
                 prop1: { type: 'string' },
             },
             RowHigherOrderComponent1: {
@@ -92,7 +84,6 @@ describe('parser', () => {
                 prop1: { type: 'string' },
             },
             ColumnExternalHigherOrderComponent: {
-                children,
                 prop1: { type: 'string' },
             },
             RowExternalHigherOrderComponent: {
@@ -104,7 +95,6 @@ describe('parser', () => {
     it('should parse component with inherited properties HtmlAttributes<any>', function(){
         check('ColumnWithHtmlAttributes', {
             Column: {
-                children,
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
                 // HtmlAttributes
@@ -121,7 +111,6 @@ describe('parser', () => {
     it('should parse component without exported props interface', function(){
         check('ColumnWithoutExportedProps', {
             Column: {
-                children,
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
             }
@@ -143,7 +132,6 @@ describe('parser', () => {
     it('should parse react component with properties defined in external file', function(){
         check('ExternalPropsComponent', {
             ExternalPropsComponent: {
-                children,
                 prop1: { type: 'string' },
             }
         });
@@ -152,7 +140,6 @@ describe('parser', () => {
     it('should parse react component with properties extended from an external .tsx file', function(){
         check('ExtendsExternalPropsComponent', {
             ExtendsExternalPropsComponent: {
-                children,
                 prop1: { type: 'number', required: false, description: 'prop1' },
                 prop2: { type: 'string', required: false, description: 'prop2' },
             }
@@ -162,7 +149,6 @@ describe('parser', () => {
     it('should parse react component with properties defined as type', function(){
         check('FlippableImage', {
             FlippableImage: {
-                children,
                 isFlippedX: { type: 'boolean', required: false },
                 isFlippedY: { type: 'boolean', required: false },
             }
@@ -172,7 +158,6 @@ describe('parser', () => {
     it('should parse react component with const definitions', function(){
         check('InlineConst', {
             MyComponent: {
-                children,
                 foo: { type: 'any' },
             }
         });
@@ -181,7 +166,6 @@ describe('parser', () => {
     it('should parse react component with default props', function(){
         check('ComponentWithDefaultProps', {
             ComponentWithDefaultProps: {
-                children,
                 sampleDefaultFromJSDoc: { type: '"hello" | "goodbye"', required: true, defaultValue: "hello", description: 'sample with default value' },
                 sampleTrue: { type: "boolean", required: false, defaultValue: "true" },
                 sampleFalse: { type: "boolean", required: false, defaultValue: "false" },
@@ -196,7 +180,6 @@ describe('parser', () => {
     it('should parse react PureComponent', function(){
         check('PureRow', {
             Row: {
-                children,
                 prop1: { type: 'string', required: false },
                 prop2: { type: 'number' },
             }
@@ -206,7 +189,6 @@ describe('parser', () => {
     it('should parse react PureComponent - regression test', function(){
         check('Regression_v0_0_12', {
             Zoomable: {
-                children,
                 originX: { type: 'number' },
                 originY: { type: 'number' },
                 scaleFactor: { type: 'number' }
@@ -226,7 +208,6 @@ describe('parser', () => {
     it('should parse react stateless component', function(){
         check('Stateless', {
             Stateless: {
-                children,
                 myProp: { type: 'string' },
             }
         });
@@ -235,7 +216,6 @@ describe('parser', () => {
     it('should parse react stateless component with default props', function(){
         check('StatelessWithDefaultProps', {
             StatelessWithDefaultProps: {
-                children,
                 sampleJSDoc: { type: "string", required: false, defaultValue: "test" },
                 sampleProp: { type: "string", required: false, defaultValue: "hello" },
             }

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -17,7 +17,6 @@ describe('parser', () => {
         });
     });
 
-
     it('should parse simple react class component as default export', function() {
         check('ColumnWithDefaultExport', {
             Column: {
@@ -283,4 +282,36 @@ describe('parser', () => {
             }
         }, true, 'Jumbotron description');
     });    
+
+    describe('parser options', function() {
+
+        describe('ignoreChildrenPropIfNoDocAvailable', function() {
+
+            it('should ignore "children" property if not documented explicitly', function() {
+                check('Column', {
+                    Column: {
+                        prop1: { type: 'string', required: false },
+                        prop2: { type: 'number' },
+                        prop3: { type: '() => void'},
+                        prop4: { type: '"option1" | "option2" | "option3"' },
+                    }
+                }, true, null, { ignoreChildrenIfNoDocAvailable: true });
+            });
+
+            it('should not ignore "children" property if documented explicitly', function() {
+                check('ColumnWithAnnotatedChildren', {
+                    Column: {
+                        children: { type: 'ReactNode', required: false, description: 'children description'},
+                        prop1: { type: 'string', required: false },
+                        prop2: { type: 'number' },
+                        prop3: { type: '() => void'},
+                        prop4: { type: '"option1" | "option2" | "option3"' }
+                    }
+                }, true, null, { ignoreChildrenIfNoDocAvailable: true });
+            });
+
+        });
+
+    });
+
 });

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -287,7 +287,7 @@ describe('parser', () => {
     describe('Parser options', function() {
 
         describe('Property filtering', function() {
-            const propFilter: PropFilter = (prop, componentName) => prop.name && prop.description.length > 0
+            const propFilter: PropFilter = (prop, component) => prop.name && prop.description.length > 0
 
             it('should ignore any property that is not documented explicitly', function() {
                 check('Column', {

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import { check } from "./testUtils";
+import { PropsFilter } from '../parser';
 
 describe('parser', () => {
 
@@ -286,6 +287,7 @@ describe('parser', () => {
     describe('parser options', function() {
 
         describe('ignoreChildrenPropIfNoDocAvailable', function() {
+            const propsFilter: PropsFilter = (prop, componentName) => prop.name && prop.description.length > 0
 
             it('should ignore "children" property if not documented explicitly', function() {
                 check('Column', {
@@ -295,7 +297,7 @@ describe('parser', () => {
                         prop3: { type: '() => void'},
                         prop4: { type: '"option1" | "option2" | "option3"' },
                     }
-                }, true, null, { ignoreChildrenIfNoDocAvailable: true });
+                }, true, null, { propsFilter });
             });
 
             it('should not ignore "children" property if documented explicitly', function() {
@@ -307,7 +309,7 @@ describe('parser', () => {
                         prop3: { type: '() => void'},
                         prop4: { type: '"option1" | "option2" | "option3"' }
                     }
-                }, true, null, { ignoreChildrenIfNoDocAvailable: true });
+                }, true, null, { propsFilter });
             });
 
         });

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -284,12 +284,12 @@ describe('parser', () => {
         }, true, 'Jumbotron description');
     });    
 
-    describe('parser options', function() {
+    describe('Parser options', function() {
 
-        describe('ignoreChildrenPropIfNoDocAvailable', function() {
+        describe('Property filtering', function() {
             const propsFilter: PropsFilter = (prop, componentName) => prop.name && prop.description.length > 0
 
-            it('should ignore "children" property if not documented explicitly', function() {
+            it('should ignore any property that is not documented explicitly', function() {
                 check('Column', {
                     Column: {
                         prop1: { type: 'string', required: false },
@@ -300,7 +300,7 @@ describe('parser', () => {
                 }, true, null, { propsFilter });
             });
 
-            it('should not ignore "children" property if documented explicitly', function() {
+            it('should not ignore any property that is documented explicitly', function() {
                 check('ColumnWithAnnotatedChildren', {
                     Column: {
                         children: { type: 'ReactNode', required: false, description: 'children description'},

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import * as path from 'path';
-import { parse, ComponentDoc, PropItem } from '../parser';
+import { parse, ComponentDoc, PropItem, defaultParserOpts, ParserOptions } from '../parser';
 
 export interface ExpectedComponents {
     [key: string]: ExpectedComponent;
@@ -18,10 +18,10 @@ export interface ExpectedProp {
 }
 
 export function check(component: string, expected: ExpectedComponents, 
-    exactProperties: boolean = true, description: string = null) {
+    exactProperties: boolean = true, description: string = null, parserOpts?: ParserOptions) {
 
     const fileName = path.join(__dirname, '../../src/__tests__/data', `${component}.tsx`); // it's running in ./temp
-    const result = parse(fileName);
+    const result = parse(fileName, parserOpts);
     checkComponent(result, expected, exactProperties, description);
 }
 

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import * as path from 'path';
-import { parse, ComponentDoc, PropItem, defaultParserOpts, ParserOptions } from '../parser';
+import { parse, ComponentDoc, defaultParserOpts, ParserOptions } from '../parser';
 
 export interface ExpectedComponents {
     [key: string]: ExpectedComponent;

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -1,0 +1,28 @@
+import { ParserOptions, PropItem, Component, PropFilter, StaticPropFilter } from './parser';
+
+export function buildFilter(opts: ParserOptions): PropFilter {
+  return (prop: PropItem, component: Component) => {
+    const { propFilter } = opts;
+    // skip children property in case it has no custom documentation
+    if (prop.name === 'children' && prop.description.length === 0) {
+      return false;
+    }
+    if (typeof propFilter === 'function') {
+      const keep = propFilter(prop, component);
+      if (!keep) {
+        return false;
+      }
+    } else if (typeof propFilter === 'object') {
+      const { skipPropsWithName, skipPropsWithoutDoc } = propFilter as StaticPropFilter;
+      if (typeof skipPropsWithName === 'string' && skipPropsWithName === prop.name) {
+        return false;
+      } else if (Array.isArray(skipPropsWithName) && skipPropsWithName.indexOf(prop.name) > -1) {
+        return false;
+      }
+      if (skipPropsWithoutDoc && prop.description.length === 0) {
+        return false;
+      }
+    }
+    return true;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
     withCustomConfig,
     ComponentDoc,
     Props,
+    Prop,
     PropItem,
     PropItemType,
 } from './parser';
@@ -14,6 +15,7 @@ export {
     withCustomConfig,
     ComponentDoc,
     Props,
+    Prop,
     PropItem,
     PropItemType,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import {
     withCustomConfig,
     ComponentDoc,
     Props,
-    Prop,
     PropItem,
     PropItemType,
 } from './parser';
@@ -15,7 +14,6 @@ export {
     withCustomConfig,
     ComponentDoc,
     Props,
-    Prop,
     PropItem,
     PropItemType,
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -157,11 +157,17 @@ class Parser {
             const defaultProps = this.extractDefaultPropsFromComponent(exp, source);
             const props = this.getPropsInfo(propsType, defaultProps);
 
-            if (typeof this.opts.propFilter === 'function') {
-              for (const propName of Object.keys(props)) {
-                const prop = props[propName];
-                const propItem: PropItem & PropItemType = {...prop, name: propName };
-                const component: Component = { name: componentName };
+            for (const propName of Object.keys(props)) {
+              const prop = props[propName];
+              const propItem: PropItem & PropItemType = {...prop, name: propName };
+
+              // skip children property in case it has no custom documentation
+              if (propItem.name === 'children' && prop.description.length === 0) {
+                delete props[propName];
+              }
+
+              const component: Component = { name: componentName };
+              if (typeof this.opts.propFilter === 'function') {
                 const keep = this.opts.propFilter(propItem, component);
                 if (!keep) {
                   delete props[propName];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,12 +21,20 @@ export interface PropItem {
     defaultValue: any;
 }
 
+export interface Prop extends PropItem {
+  name: string;
+}
+
+export interface Component {
+  name: string;
+}
+
 export interface PropItemType {
     name: string;
     value?: any;
 }
 
-export type PropFilter = (props: PropItem & PropItemType, componentName: string) => boolean;
+export type PropFilter = (props: Prop, componentName: Component) => boolean;
 
 export interface ParserOptions {
   propFilter?: PropFilter
@@ -153,7 +161,8 @@ class Parser {
               for (const propName of Object.keys(props)) {
                 const prop = props[propName];
                 const propItem: PropItem & PropItemType = {...prop, name: propName };
-                const keep = this.opts.propFilter(propItem, componentName);
+                const component: Component = { name: componentName };
+                const keep = this.opts.propFilter(propItem, component);
                 if (!keep) {
                   delete props[propName];
                 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,10 +26,10 @@ export interface PropItemType {
     value?: any;
 }
 
-export type PropsFilter = (props: PropItem & PropItemType, componentName: string) => boolean;
+export type PropFilter = (props: PropItem & PropItemType, componentName: string) => boolean;
 
 export interface ParserOptions {
-  propsFilter?: PropsFilter
+  propFilter?: PropFilter
 }
 
 export const defaultParserOpts: ParserOptions = {};
@@ -149,11 +149,11 @@ class Parser {
             const defaultProps = this.extractDefaultPropsFromComponent(exp, source);
             const props = this.getPropsInfo(propsType, defaultProps);
 
-            if (typeof this.opts.propsFilter === 'function') {
+            if (typeof this.opts.propFilter === 'function') {
               for (const propName of Object.keys(props)) {
                 const prop = props[propName];
                 const propItem: PropItem & PropItemType = {...prop, name: propName };
-                const keep = this.opts.propsFilter(propItem, componentName);
+                const keep = this.opts.propFilter(propItem, componentName);
                 if (!keep) {
                   delete props[propName];
                 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,13 +12,13 @@ export interface ComponentDoc {
     props: Props;
 }
 
-export interface Props extends StringIndexedObject<PropItem> { }
+export interface Props extends StringIndexedObject<Prop> { }
 
 export interface PropItem {
-    required: boolean;
-    type: PropItemType;
-    description: string;
-    defaultValue: any;
+  required: boolean;
+  type: PropItemType;
+  description: string;
+  defaultValue: any;
 }
 
 export interface Prop extends PropItem {
@@ -159,16 +159,15 @@ class Parser {
 
             for (const propName of Object.keys(props)) {
               const prop = props[propName];
-              const propItem: PropItem & PropItemType = {...prop, name: propName };
 
               // skip children property in case it has no custom documentation
-              if (propItem.name === 'children' && prop.description.length === 0) {
+              if (prop.name === 'children' && prop.description.length === 0) {
                 delete props[propName];
               }
 
               const component: Component = { name: componentName };
               if (typeof this.opts.propFilter === 'function') {
-                const keep = this.opts.propFilter(propItem, component);
+                const keep = this.opts.propFilter(prop, component);
                 if (!keep) {
                   delete props[propName];
                 }
@@ -257,6 +256,7 @@ class Parser {
             }
 
             result[propName] = {
+                name: propName,
                 required: !isOptional,
                 type: { name: propTypeString },
                 description: jsDocComment.fullComment,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,17 +12,14 @@ export interface ComponentDoc {
     props: Props;
 }
 
-export interface Props extends StringIndexedObject<Prop> { }
+export interface Props extends StringIndexedObject<PropItem> { }
 
 export interface PropItem {
+  name: string;
   required: boolean;
   type: PropItemType;
   description: string;
   defaultValue: any;
-}
-
-export interface Prop extends PropItem {
-  name: string;
 }
 
 export interface Component {
@@ -34,7 +31,7 @@ export interface PropItemType {
     value?: any;
 }
 
-export type PropFilter = (props: Prop, componentName: Component) => boolean;
+export type PropFilter = (props: PropItem, componentName: Component) => boolean;
 
 export interface ParserOptions {
   propFilter?: PropFilter

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,7 +31,7 @@ export interface PropItemType {
     value?: any;
 }
 
-export type PropFilter = (props: PropItem, componentName: Component) => boolean;
+export type PropFilter = (props: PropItem, component: Component) => boolean;
 
 export interface ParserOptions {
   propFilter?: StaticPropFilter | PropFilter

--- a/src/propTypesParser.ts
+++ b/src/propTypesParser.ts
@@ -2,7 +2,6 @@ import {
     parse as newParse, 
     ComponentDoc,
     Props,
-    PropItem,
     PropItemType
 } from './parser';
 


### PR DESCRIPTION
In case the "children" property has not been documented by the user the property should be ignored when creating the documentation.
But the property should be respected in case the user has specifically documented the "children" property.

I've introduced a config object that can be used to change the default behaviour by setting `ignoreChildrenIfNoDocAvailable = true`, which will then ignore any children properties that are not documented.

To configure the parser accordingly the following snippet can be used:

```javascript
propsParser: require('react-docgen-typescript')
  .withCustomConfig('./tsconfig.json', {ignoreChildrenIfNoDocAvailable: true})
  .parse
```