### PR TITLE
Fix React.SFC-typed functional components

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "tsc": "tsc",
-    "prepublish": "tsc -d",
+    "prepublishOnly": "tsc -d",
     "test": "tsc && mocha --timeout 10000 ./lib/**/__tests__/**.js",
     "test:debug": "tsc && mocha --debug ./lib/**/__tests__/**.js",
     "print": "npm run tsc && node ./lib/print.js",

--- a/src/__tests__/data/ReactSFCAsConst.tsx
+++ b/src/__tests__/data/ReactSFCAsConst.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+/** JumbotronProps props */
+export interface JumbotronProps {
+  /** prop1 description */
+  prop1: string;
+}
+
+/**
+ * Jumbotron description
+ */
+export const Jumbotron: React.SFC<JumbotronProps> = props => {
+  return <div>Test</div>;
+};

--- a/src/__tests__/data/ReactSFCAsConstAsDefaultExport.tsx
+++ b/src/__tests__/data/ReactSFCAsConstAsDefaultExport.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+/** JumbotronProps props */
+export interface JumbotronProps {
+  /** prop1 description */
+  prop1: string;
+}
+
+/**
+ * Jumbotron description
+ */
+const Jumbotron: React.SFC<JumbotronProps> = props => {
+  return <div>Test</div>;
+};
+
+export default Jumbotron;

--- a/src/__tests__/data/ReactSFCAsConstAsNamedExport.tsx
+++ b/src/__tests__/data/ReactSFCAsConstAsNamedExport.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+/** JumbotronProps props */
+export interface JumbotronProps {
+  /** prop1 description */
+  prop1: string;
+}
+
+/**
+ * Jumbotron description
+ */
+const Jumbotron: React.SFC<JumbotronProps> = props => {
+  return <div>Test</div>;
+};
+
+export { Jumbotron };

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -277,6 +277,14 @@ describe('parser', () => {
     });
   });
 
+  it('should parse React.SFC component defined as const', () => {
+    check('ReactSFCAsConst', {
+      Jumbotron: {
+        prop1: { type: 'string', required: true }
+      }
+    });
+  });
+
   it('should parse functional component component defined as function as default export', () => {
     check('FunctionDeclarationAsDefaultExport', {
       Jumbotron: {
@@ -299,12 +307,40 @@ describe('parser', () => {
     );
   });
 
+  it('should parse React.SFC component defined as const as default export', () => {
+    check(
+      'ReactSFCAsConstAsDefaultExport',
+      {
+        // in this case the component name is taken from the file name
+        ReactSFCAsConstAsDefaultExport: {
+          prop1: { type: 'string', required: true }
+        }
+      },
+      true,
+      'Jumbotron description'
+    );
+  });
+
   it('should parse functional component component defined as const as named export', () => {
     check(
       'FunctionalComponentAsConstAsNamedExport',
       {
         // in this case the component name is taken from the file name
         FunctionalComponentAsConstAsNamedExport: {
+          prop1: { type: 'string', required: true }
+        }
+      },
+      true,
+      'Jumbotron description'
+    );
+  });
+
+  it('should parse React.SFC component defined as const as named export', () => {
+    check(
+      'ReactSFCAsConstAsNamedExport',
+      {
+        // in this case the component name is taken from the file name
+        ReactSFCAsConstAsNamedExport: {
           prop1: { type: 'string', required: true }
         }
       },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -185,11 +185,17 @@ class Parser {
       exp,
       exp.valueDeclaration || exp.declarations![0]
     );
+    let commentSource = exp;
     if (!exp.valueDeclaration) {
       if (!type.symbol) {
         return null;
       }
       exp = type.symbol;
+      if (type.symbol.getName() === 'StatelessComponent') {
+        commentSource = this.checker.getAliasedSymbol(commentSource);
+      } else {
+        commentSource = exp;
+      }
     }
 
     let propsType = this.extractPropsFromTypeIfStatelessComponent(type);
@@ -211,7 +217,7 @@ class Parser {
       }
 
       return {
-        description: this.findDocComment(exp).fullComment,
+        description: this.findDocComment(commentSource).fullComment,
         displayName: componentName,
         props
       };
@@ -486,7 +492,11 @@ function formatTag(tag: ts.JSDocTagInfo) {
 function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
   const exportName = exp.getName();
 
-  if (exportName === 'default' || exportName === '__function') {
+  if (
+    exportName === 'default' ||
+    exportName === '__function' ||
+    exportName === 'StatelessComponent'
+  ) {
     // Default export for a file: named after file
     return path.basename(source.fileName, path.extname(source.fileName));
   } else {


### PR DESCRIPTION
Closes #74 

I also have a `prepublishOnly` change in here -- I can remove it if you want, but it's a little better for other contributors (don't need `tsc` installed globally, and also no potential version mismatch)

Also noticed that this doesn't compile with TS2.7, so the typescript@^2.6.2 doesn't work with a fresh install