### PR TITLE
Extracts default props from stateless components

### DIFF
--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -256,7 +256,7 @@ describe('parser', () => {
     check('StatelessWithDefaultProps', {
       StatelessWithDefaultProps: {
         sampleJSDoc: { type: 'string', required: false, defaultValue: 'test' },
-        sampleProp: { type: 'string', required: false, defaultValue: 'hello' }
+        sampleProp: { type: 'string', required: false, defaultValue: 'test' }
       }
     });
   });


### PR DESCRIPTION
The current implementation of `extractPropsFromTypeIfStatelessComponent()` in `src/parser.ts` works only with classes and lacks support for stateless components.

Paradoxically, there is a test located at `src/__tests__/parser.ts`, named 'should parse react stateless component with default props', which always returns true and does not actually check the default value (although 'hello' is expected and 'test' is returned, that test always passes).

This PR adds support for extracting default props from stateless components, and fixes the above test.