### PR TITLE
Fix/default props

### DIFF
--- a/src/__tests__/data/ComponentWithReferencedDefaultProps.tsx
+++ b/src/__tests__/data/ComponentWithReferencedDefaultProps.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+/** IComponentWithDefaultPropsProps props */
+export interface IComponentWithDefaultPropsProps {
+  /**
+   * sample with default value
+   * @default hello
+   */
+  sampleDefaultFromJSDoc: 'hello' | 'goodbye';
+  /** sampleTrue description */
+  sampleTrue?: boolean;
+  /** sampleFalse description */
+  sampleFalse?: boolean;
+  /** sampleString description */
+  sampleString?: string;
+  /** sampleObject description */
+  sampleObject?: { [key: string]: any };
+  /** sampleNull description */
+  sampleNull?: null;
+  /** sampleUndefined description */
+  sampleUndefined?: any;
+  /** sampleNumber description */
+  sampleNumber?: number;
+}
+
+const defaultProps: Partial<IComponentWithDefaultPropsProps> = {
+  sampleFalse: false,
+  sampleNull: null,
+  sampleNumber: -1,
+  // prettier-ignore
+  sampleObject: { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
+  sampleString: 'hello',
+  sampleTrue: true,
+  sampleUndefined: undefined
+};
+
+/** ComponentWithDefaultProps description */
+export class ComponentWithDefaultProps extends React.Component<
+  IComponentWithDefaultPropsProps,
+  {}
+> {
+  static defaultProps: Partial<IComponentWithDefaultPropsProps> = defaultProps;
+
+  public render() {
+    return <div>test</div>;
+  }
+}

--- a/src/__tests__/data/ComponentWithReferencedDefaultProps.tsx
+++ b/src/__tests__/data/ComponentWithReferencedDefaultProps.tsx
@@ -34,12 +34,16 @@ const defaultProps: Partial<IComponentWithDefaultPropsProps> = {
   sampleUndefined: undefined
 };
 
+const defaultPropsReference = defaultProps;
+
 /** ComponentWithDefaultProps description */
 export class ComponentWithDefaultProps extends React.Component<
   IComponentWithDefaultPropsProps,
   {}
 > {
-  static defaultProps: Partial<IComponentWithDefaultPropsProps> = defaultProps;
+  static defaultProps: Partial<
+    IComponentWithDefaultPropsProps
+  > = defaultPropsReference;
 
   public render() {
     return <div>test</div>;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -176,7 +176,7 @@ describe('parser', () => {
     });
   });
 
-  describe.only('component with default props', () => {
+  describe('component with default props', () => {
     const expectation = {
       ComponentWithDefaultProps: {
         sampleDefaultFromJSDoc: {

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -176,8 +176,8 @@ describe('parser', () => {
     });
   });
 
-  it('should parse react component with default props', () => {
-    check('ComponentWithDefaultProps', {
+  describe.only('component with default props', () => {
+    const expectation = {
       ComponentWithDefaultProps: {
         sampleDefaultFromJSDoc: {
           defaultValue: 'hello',
@@ -209,6 +209,14 @@ describe('parser', () => {
           type: 'any'
         }
       }
+    };
+
+    it('should parse defined props', () => {
+      check('ComponentWithDefaultProps', expectation);
+    });
+
+    it('should parse referenced props', () => {
+      check('ComponentWithReferencedDefaultProps', expectation);
     });
   });
 


### PR DESCRIPTION
hello!

i noticed that `react-docgen-typescript` is not able to parse referenced default props. This means the following is okay:
```js
static defaultProps = { /* ... */ }
```
but the following breaks:
```js
const defaultProps = { /* ... */ };
// later in class
static defaultProps = defaultProps
```

here's mocha complaining
```
  parser
    component with default props
      ✓ should parse defined props (563ms)
      1) should parse referenced props


  1 passing (952ms)
  1 failing

  1) parser
       component with default props
         should parse referenced props:
     TypeError: Cannot read property 'reduce' of undefined
      at getPropMap (src/parser.ts:466:29)
      at Parser.extractDefaultPropsFromComponent (src/parser.ts:422:23)
      at Parser.getComponentInfo (src/parser.ts:208:33)
      at src/parser.ts:132:28
      at Array.map (native)
      at Object.parse (src/parser.ts:132:10)
      at Object.parse (src/parser.ts:67:58)
      at Object.check (src/__tests__/testUtils.ts:37:18)
      at Context.<anonymous> (src/__tests__/parser.ts:219:7)
```

this PR makes `react-docgen-typescript` support referenced default props.

However, due to my *very* limited knowledge of typescript parser, the implementation feels wonky to me. Moreover, this PR does not consider default props being imported from another file. This should be done in separate PR anyway.

Please let me know what you think. It'd be great to get this feature working as currently im unable to generate documentation for a bunch of components.

Thanks for your work!