### PR TITLE
Add Support for Referenced Default Props in Stateless Components

### DIFF
--- a/src/__tests__/data/StatelessWithReferencedDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithReferencedDefaultProps.tsx
@@ -23,12 +23,7 @@ export interface StatelessWithDefaultPropsProps {
   sampleNumber?: number;
 }
 
-/** StatelessWithDefaultProps description */
-export const StatelessWithDefaultProps: React.StatelessComponent<
-StatelessWithDefaultPropsProps
-> = props => <div>test</div>;
-
-StatelessWithDefaultProps.defaultProps = {
+const defaultProps: Partial<StatelessWithDefaultPropsProps> = {
   sampleFalse: false,
   sampleNull: null,
   sampleNumber: -1,
@@ -38,3 +33,12 @@ StatelessWithDefaultProps.defaultProps = {
   sampleTrue: true,
   sampleUndefined: undefined
 };
+
+const defaultPropsReference = defaultProps;
+
+/** StatelessWithDefaultProps description */
+export const StatelessWithDefaultProps: React.StatelessComponent<
+StatelessWithDefaultPropsProps
+> = props => <div>test</div>;
+
+StatelessWithDefaultProps.defaultProps = defaultProps;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -260,12 +260,47 @@ describe('parser', () => {
     });
   });
 
-  it('should parse react stateless component with default props', () => {
-    check('StatelessWithDefaultProps', {
+  describe('stateless component with default props', () => {
+    const expectation = {
       StatelessWithDefaultProps: {
-        sampleJSDoc: { type: 'string', required: false, defaultValue: 'test' },
-        sampleProp: { type: 'string', required: false, defaultValue: 'test' }
+        sampleDefaultFromJSDoc: {
+          defaultValue: 'hello',
+          description: 'sample with default value',
+          required: true,
+          type: '"hello" | "goodbye"'
+        },
+        sampleFalse: {
+          defaultValue: 'false',
+          required: false,
+          type: 'boolean'
+        },
+        sampleNull: { type: 'null', required: false, defaultValue: 'null' },
+        sampleNumber: { type: 'number', required: false, defaultValue: '-1' },
+        sampleObject: {
+          defaultValue: `{ a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } }`,
+          required: false,
+          type: '{ [key: string]: any; }'
+        },
+        sampleString: {
+          defaultValue: 'hello',
+          required: false,
+          type: 'string'
+        },
+        sampleTrue: { type: 'boolean', required: false, defaultValue: 'true' },
+        sampleUndefined: {
+          defaultValue: 'undefined',
+          required: false,
+          type: 'any'
+        }
       }
+    };
+
+    it('should parse defined props', () => {
+      check('StatelessWithDefaultProps', expectation);
+    });
+
+    it('should parse referenced props', () => {
+      check('StatelessWithReferencedDefaultProps', expectation);
     });
   });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -122,6 +122,10 @@ export function withCompilerOptions(
       const checker = program.getTypeChecker();
       const sourceFile = program.getSourceFile(filePath);
 
+      if (!sourceFile) {
+        return [];
+      }
+
       const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
       if (!moduleSymbol) {
         return [];
@@ -439,9 +443,13 @@ class Parser {
         }
       }
 
-      const propMap = getPropMap(properties as ts.NodeArray<
-        ts.PropertyAssignment
-      >);
+      let propMap = {};
+
+      if (properties) {
+        propMap = getPropMap(properties as ts.NodeArray<
+          ts.PropertyAssignment
+        >);
+      }
 
       return propMap;
     } else if (statementIsStateless(statement)) {
@@ -450,9 +458,11 @@ class Parser {
         const { right } = child as ts.BinaryExpression;
         if (right) {
           const { properties } = right as ts.ObjectLiteralExpression;
-          propMap = getPropMap(properties as ts.NodeArray<
-            ts.PropertyAssignment
-          >);
+          if (properties) {
+            propMap = getPropMap(properties as ts.NodeArray<
+              ts.PropertyAssignment
+            >);
+          }
         }
       });
       return propMap;


### PR DESCRIPTION
Hi!

Pull Request #80 added support for referenced default props. This only worked in components declared with `class`, not as `StatelessComponent`.

Based on #80, I improved the tests for default prop parsing for stateless components, and prevented the error `TypeError: Cannot read property 'reduce' of undefined` by checking if `properties` is defined before calling `getPropMap`. This turned out to be enough to fix the issue.

Please let me know what you think, and thank you for your work so far!