### PR TITLE
Fix/extract display name

### DIFF
--- a/src/__tests__/data/StatefulDisplayName.tsx
+++ b/src/__tests__/data/StatefulDisplayName.tsx
@@ -7,7 +7,7 @@ export interface StatefullProps {
 
 /** Statefull description */
 export class Statefull extends React.Component<StatefullProps> {
-  static displayName = 'i am stateless displayName';
+  static displayName = 'i am stateful displayName';
   render() {
     return <div>My Property = {this.props.myProp}</div>;
   }

--- a/src/__tests__/data/StatefulDisplayName.tsx
+++ b/src/__tests__/data/StatefulDisplayName.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface StatefullProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** Statefull description */
+export class Statefull extends React.Component<StatefullProps> {
+  static displayName = 'i am stateless displayName';
+  render() {
+    return <div>My Property = {this.props.myProp}</div>;
+  }
+}

--- a/src/__tests__/data/StatelessDisplayName.tsx
+++ b/src/__tests__/data/StatelessDisplayName.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export interface StatelessProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** Stateless description */
+export const Stateless: React.StatelessComponent<StatelessProps> = props => (
+  <div>My Property = {props.myProp}</div>
+);
+
+Stateless.displayName = 'i am stateless displayName';

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -392,17 +392,15 @@ describe('parser', () => {
     );
   });
 
-  describe.only('displayName', () => {
+  describe('displayName', () => {
     it('should be taken from stateless component `displayName` property', () => {
       const [parsed] = parse(fixturePath('StatelessDisplayName'));
-      console.log(parsed);
       assert.equal(parsed.displayName, 'i am stateless displayName');
     });
 
     it('should be taken from stateful component `displayName` property', () => {
       const [parsed] = parse(fixturePath('StatefulDisplayName'));
-      console.log(parsed);
-      assert.equal(parsed.displayName, 'i am stateless displayName');
+      assert.equal(parsed.displayName, 'i am stateful displayName');
     });
   });
 

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import * as path from 'path';
-import { PropFilter, withCustomConfig } from '../parser';
-import { check } from './testUtils';
+import { parse, PropFilter, withCustomConfig } from '../parser';
+import { check, fixturePath } from './testUtils';
 
 describe('parser', () => {
   const children = { type: 'ReactNode', required: false, description: '' };
@@ -390,6 +390,20 @@ describe('parser', () => {
       true,
       'Jumbotron description'
     );
+  });
+
+  describe.only('displayName', () => {
+    it('should be taken from stateless component `displayName` property', () => {
+      const [parsed] = parse(fixturePath('StatelessDisplayName'));
+      console.log(parsed);
+      assert.equal(parsed.displayName, 'i am stateless displayName');
+    });
+
+    it('should be taken from stateful component `displayName` property', () => {
+      const [parsed] = parse(fixturePath('StatefulDisplayName'));
+      console.log(parsed);
+      assert.equal(parsed.displayName, 'i am stateless displayName');
+    });
   });
 
   describe('Parser options', () => {

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -22,19 +22,26 @@ export interface ExpectedProp {
   defaultValue?: string;
 }
 
+export function fixturePath(componentName: string) {
+  return path.join(
+    __dirname,
+    '..',
+    '..',
+    'src',
+    '__tests__',
+    'data',
+    `${componentName}.tsx`
+  ); // it's running in ./temp
+}
+
 export function check(
-  component: string,
+  componentName: string,
   expected: ExpectedComponents,
   exactProperties: boolean = true,
   description?: string,
   parserOpts?: ParserOptions
 ) {
-  const fileName = path.join(
-    __dirname,
-    '../../src/__tests__/data',
-    `${component}.tsx`
-  ); // it's running in ./temp
-  const result = parse(fileName, parserOpts);
+  const result = parse(fixturePath(componentName), parserOpts);
   checkComponent(result, expected, exactProperties, description);
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -581,17 +581,19 @@ function getTextValueOfClassMember(
   return textValue || '';
 }
 
-function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
-  const exportName = exp.getName();
-
-  const [statelessDisplayName] = source.statements
+function getTextValueOfFunctionProperty(
+  exp: ts.Symbol,
+  source: ts.SourceFile,
+  propertyName: string
+) {
+  const [textValue] = source.statements
     .filter(statement => ts.isExpressionStatement(statement))
     .filter(statement => {
       const expr = (statement as ts.ExpressionStatement)
         .expression as ts.BinaryExpression;
       return (
         (expr.left as ts.PropertyAccessExpression).name.escapedText ===
-        'displayName'
+        propertyName
       );
     })
     .filter(statement => {
@@ -613,6 +615,18 @@ function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
       return (((statement as ts.ExpressionStatement)
         .expression as ts.BinaryExpression).right as ts.Identifier).text;
     });
+
+  return textValue || '';
+}
+
+function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
+  const exportName = exp.getName();
+
+  const statelessDisplayName = getTextValueOfFunctionProperty(
+    exp,
+    source,
+    'displayName'
+  );
 
   let statefulDisplayName;
   if (exp.valueDeclaration && ts.isClassDeclaration(exp.valueDeclaration)) {


### PR DESCRIPTION
closes #82 
closes #72 

@pvasek a non ideal but much better than nothing way to use `displayName`.

logic, essentially, is if `displayName` is extracted from stateless or functional component, then use that. otherwise fall back to previous logic without changes.

please let me know what you think. i think this would be a good improvement regarding component names in documentation :)