### PR TITLE
Support spread default props

### DIFF
--- a/src/__tests__/data/StatelessWithSpreadDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithSpreadDefaultProps.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+/** StatelessWithDefaultProps props */
+export interface StatelessWithDefaultPropsProps {
+  /**
+   * sample with default value
+   * @default hello
+   */
+  sampleDefaultFromJSDoc: 'hello' | 'goodbye';
+  /** sampleTrue description */
+  sampleTrue?: boolean;
+  /** sampleFalse description */
+  sampleFalse?: boolean;
+  /** sampleString description */
+  sampleString?: string;
+  /** sampleObject description */
+  sampleObject?: { [key: string]: any };
+  /** sampleNull description */
+  sampleNull?: null;
+  /** sampleUndefined description */
+  sampleUndefined?: any;
+  /** sampleNumber description */
+  sampleNumber?: number;
+}
+
+/** StatelessWithDefaultProps description */
+export const StatelessWithDefaultProps: React.StatelessComponent<
+  StatelessWithDefaultPropsProps
+> = props => <div>test</div>;
+
+const defaultProps = {
+  sampleFalse: false,
+  sampleNull: null,
+  sampleNumber: -1
+};
+
+StatelessWithDefaultProps.defaultProps = {
+  ...defaultProps,
+  // prettier-ignore
+  sampleObject: { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
+  sampleString: 'hello',
+  sampleTrue: true,
+  sampleUndefined: undefined
+};

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -302,6 +302,10 @@ describe('parser', () => {
     it('should parse referenced props', () => {
       check('StatelessWithReferencedDefaultProps', expectation);
     });
+
+    it('supports spread props', () => {
+      check('StatelessWithSpreadDefaultProps', expectation);
+    });
   });
 
   it('should parse functional component component defined as function', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -447,7 +447,10 @@ class Parser {
       let propMap = {};
 
       if (properties) {
-        propMap = getPropMap(properties as ts.NodeArray<ts.PropertyAssignment>);
+        propMap = getPropMap(
+          properties as ts.NodeArray<ts.PropertyAssignment>,
+          source
+        );
       }
 
       return propMap;
@@ -458,9 +461,10 @@ class Parser {
         if (right) {
           const { properties } = right as ts.ObjectLiteralExpression;
           if (properties) {
-            propMap = getPropMap(properties as ts.NodeArray<
-              ts.PropertyAssignment
-            >);
+            propMap = getPropMap(
+              properties as ts.NodeArray<ts.PropertyAssignment>,
+              source
+            );
           }
         }
       });
@@ -490,19 +494,75 @@ function statementIsStateless(statement: ts.Statement): boolean {
   return false;
 }
 
+function findStatementInSource(
+  source: ts.SourceFile,
+  kind: ts.SyntaxKind
+): ts.Statement[] {
+  return source.statements.filter(
+    statement => statement.kind && statement.kind === kind
+  );
+}
+
 function getPropMap(
-  properties: ts.NodeArray<ts.PropertyAssignment>
+  properties: ts.NodeArray<ts.PropertyAssignment>,
+  source: ts.SourceFile
 ): StringIndexedObject<string> {
   const propMap = properties.reduce(
     (acc, property) => {
+      if (ts.isSpreadAssignment(property)) {
+        const spread = property as ts.SpreadAssignment;
+
+        // TODO support and reference objects that are imported
+        const refStatement = findStatementInSource(
+          source,
+          ts.SyntaxKind.VariableStatement
+        ).filter(statement => {
+          const list = (statement as ts.VariableStatement).declarationList;
+
+          if (
+            !list ||
+            !list.declarations[0] ||
+            !ts.isVariableDeclaration(list.declarations[0])
+          ) {
+            return false;
+          }
+
+          const decl = list.declarations[0];
+
+          return (
+            // Matches name
+            decl.name.getText() === spread.expression.getText() &&
+            // Is an object
+            decl.initializer &&
+            ts.isObjectLiteralExpression(decl.initializer)
+          );
+        }) as ts.VariableStatement[];
+
+        if (refStatement.length === 0) {
+          return acc;
+        }
+
+        const refObject = refStatement[0].declarationList.declarations[0]
+          .initializer! as ts.ObjectLiteralExpression;
+
+        return getPropMap(
+          refObject.properties as ts.NodeArray<ts.PropertyAssignment>,
+          source
+        );
+      }
+
+      // Unknown???
+      if (!property.name) {
+        return acc;
+      }
+
       const literalValue = getLiteralValueFromPropertyAssignment(property);
       const propertyName = getPropertyName(property.name);
+
       if (typeof literalValue === 'string' && propertyName !== null) {
-        const value = getLiteralValueFromPropertyAssignment(property);
-        if (value !== null) {
-          acc[propertyName] = value;
-        }
+        acc[propertyName] = literalValue;
       }
+
       return acc;
     },
     {} as StringIndexedObject<string>


### PR DESCRIPTION
Spreading default props like so is broken.

```
const defaultProps = {
  foo: 123,
};

Component.defaultProps = {
  ...defaultProps,
};
```

This PR attempts to find the statement in the same source file and inherit it's properties. Will do imported objects in a follow-up PR.