### PR TITLE
* upgraded typescript version and fixed parsing comment problem.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "^15.4.2",
     "source-map-support": "^0.5.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
+    "typescript": "2.9.1"
   },
   "files": [
     "lib",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -361,7 +361,7 @@ class Parser {
     }
 
     const mainComment = ts.displayPartsToString(
-      symbol.getDocumentationComment()
+      symbol.getDocumentationComment(this.checker)
     );
 
     const tags = symbol.getJsDocTags() || [];


### PR DESCRIPTION
As I checked the code for new version typescript in the parser.ts `symbol.getDocumentationComment()` method need typechecker parameter. Actually I fixed it and changed as `symbol.getDocumentationComment(this.checker)`.  Also it will not be problem for old version. I tested the example and it worked properly.

Fixed #96.

