### PR TITLE
Support shorthand default props

### DIFF
--- a/src/__tests__/data/StatelessShorthandDefaultProps.tsx
+++ b/src/__tests__/data/StatelessShorthandDefaultProps.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+export interface StatelessShorthandDefaultPropsProps {
+  /** regularProp description */
+  regularProp: string;
+  /** shorthandProp description */
+  shorthandProp?: number;
+  /** onCallback description */
+  onCallback?: () => void;
+}
+
+/** StatelessShorthandDefaultProps description */
+export const StatelessShorthandDefaultProps: React.SFC<
+  StatelessShorthandDefaultPropsProps
+> = props => <div />;
+
+const shorthandProp = 123;
+
+StatelessShorthandDefaultProps.defaultProps = {
+  regularProp: 'foo',
+  shorthandProp,
+  onCallback() {}
+};

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -364,9 +364,34 @@ describe('parser', () => {
       check('StatelessWithReferencedDefaultProps', expectation);
     });
 
-    // it('supports spread props', () => {
-    //   check('StatelessWithSpreadDefaultProps', expectation);
-    // });
+    it('should parse props with shorthands', () => {
+      check('StatelessShorthandDefaultProps', {
+        StatelessShorthandDefaultProps: {
+          onCallback: {
+            defaultValue: null,
+            description: 'onCallback description',
+            required: false,
+            type: '() => void'
+          },
+          regularProp: {
+            defaultValue: 'foo',
+            description: 'regularProp description',
+            required: true,
+            type: 'string'
+          },
+          shorthandProp: {
+            defaultValue: '123',
+            description: 'shorthandProp description',
+            required: false,
+            type: 'number'
+          }
+        }
+      });
+    });
+
+    it('supports spread props', () => {
+      check('StatelessWithSpreadDefaultProps', expectation);
+    });
   });
 
   it('should parse functional component component defined as function', () => {

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -19,7 +19,7 @@ export interface ExpectedProp {
   type: string;
   required?: boolean;
   description?: string;
-  defaultValue?: string;
+  defaultValue?: string | null;
 }
 
 export function fixturePath(componentName: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,9 +915,9 @@ type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
-typescript@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
Currently, shorthand props, and method declaration props break the parser with "TypeError: Cannot read property 'kind' of undefined" errors. This PR updates the default prop parser to extract the value from shorthand, and use null for methods (not sure on the best approach here).

I needed access to the type checker, so I had to move some functions into the parser class.