### PR TITLE
WIP: Add failing test for synthetic default

### DIFF
--- a/src/__tests__/data/SyntheticDefaultComponent.tsx
+++ b/src/__tests__/data/SyntheticDefaultComponent.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export interface Props {
+  /** prop1 description */
+  prop1: boolean;
+  /** prop2 description */
+  prop2: string;
+}
+
+/**
+ * SyntheticDefaultComponent description
+ */
+export default class SimpleComponent extends React.Component<Props> {
+  render() {
+    return <div>{this.props.prop1 && this.props.prop2}</div>;
+  }
+}

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -6,6 +6,14 @@ import { check, checkComponent, fixturePath } from './testUtils';
 describe('parser', () => {
   const children = { type: 'ReactNode', required: false, description: '' };
 
+  it('should parse a react class component using synthetic default export', () => {
+    check('SyntheticDefaultComponent', {
+      SyntheticDefaultComponent: {
+        prop1: { type: 'boolean' },
+        prop2: { type: 'string' }
+      }
+    });
+  });
   it('should parse simple react class component', () => {
     check('Column', {
       Column: {


### PR DESCRIPTION
**This PR is just here to demonstrate an issue; it may not even be an issue with this package** Feel free to close if this is just noisy.

Adds a new test file which imports `React` with a synthetic default:

```
import React from 'react';
```
instead of
```
import * as React from 'react';
```

This should be fine using the compiler option allowSyntheticDefaultImports;
however it induces a test failure.