### PR TITLE
Add additional exports to module entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,24 @@
 import {
   ComponentDoc,
+  FileParser,
   parse,
+  ParserOptions,
   PropItem,
   PropItemType,
   Props,
+  withCompilerOptions,
   withCustomConfig,
   withDefaultConfig
 } from './parser';
 
 export {
   parse,
+  withCompilerOptions,
   withDefaultConfig,
   withCustomConfig,
   ComponentDoc,
+  FileParser,
+  ParserOptions,
   Props,
   PropItem,
   PropItemType


### PR DESCRIPTION
Added a few additional exports to the module's index to support use with
react-docgen-typescript-loader. This allows this package to more easily
be used as a peer dependency.

Hello, and thank you for this project. I currently wrap this project in my project `react-docgen-typescript-loader`. I would like to be able to rely on this project as a peer dependency and need some additional exports from your library.