### PR TITLE
Allow filtering by parent interface or type declaration

### DIFF
--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -630,6 +630,32 @@ describe('parser', () => {
             { propFilter }
           );
         });
+
+        it('should allow filtering by parent interface', () => {
+          const propFilter: PropFilter = (prop, component) => {
+            if (prop.parent == null) {
+              return true;
+            }
+
+            return (
+              prop.parent.fileName.indexOf('@types/react') < 0 &&
+              prop.parent.name !== 'HTMLAttributes'
+            );
+          };
+
+          check(
+            'ColumnWithHtmlAttributes',
+            {
+              Column: {
+                prop1: { type: 'string', required: false },
+                prop2: { type: 'number' }
+              }
+            },
+            true,
+            undefined,
+            { propFilter }
+          );
+        });
       });
 
       describe('skipPropsWithName', () => {


### PR DESCRIPTION
This PR adds the ability to filter props based on where they were declared.

Solves: https://github.com/styleguidist/react-docgen-typescript/issues/56#issuecomment-400928419, https://github.com/styleguidist/react-docgen-typescript/issues/49#issuecomment-410401555

## Problem

Currently we have no way of filtering props based on where they were declared. The common problem is props that extend `HTMLAttributes<T>` interface, e.g.:
```
import * as React from 'react';

export interface IButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
  size: 'large' | 'medium' | 'small';
}
```

Filtering them using `skipPropsWithoutDoc` is not enough as some aria attributes have documentation and forces the users to write documentation for props. Using `skipPropsWithName` can cause problems if names of props are the same (e.g. custom `onClick`, `onFocus` handlers).

## Proposed solution

TypeScript allows us to get the place where the prop was declared (I believe the only valid places are InterfaceDeclaration and TypeDeclaration). We could pass the name of the type the prop was declared in and filename where the declaration of the type is placed to `propFilter` so that users have more control of which props end up in documentation. Proposed change is to add `parent` object to `PropItem` interface of filter function (`(props: PropItem, component: Component) => boolean`)

```
{
  ...
  // can be undefined as the prop can be defined inline, e.g. `(props: { foo: string }) => (<div>{foo}</div>)`
  parent: {
    // Interface or TypeAlias name
    name: string;
    // full path to file where it was declared, e.g. /Users/foo/my-app/node_modules/@types/react/index.d.ts
    fileName: string;
  }
}
```

I've added test to cover use case of filtering `HTMLAttributes` and verified using StyleGuidist that they are not documented using custom interface extending from `HTMLAttributes` and using a component created via `styled-components` (which automatically add `HTMLAttributes` to html components)

Before:
<img width="1043" alt="before" src="https://user-images.githubusercontent.com/7580355/43990970-8cc2aba6-9d63-11e8-8f90-8c1368b792d0.png">

After:
<img width="996" alt="after" src="https://user-images.githubusercontent.com/7580355/43990972-92170822-9d63-11e8-879b-b0a68cb1c592.png">

using following `styleguide.config.js`:
```
module.exports = {
  propsParser: require('react-docgen-typescript').withDefaultConfig({
    propFilter: (prop) => {
      if (prop.parent == null) {
        return true;
      }

      return prop.parent.fileName.indexOf('node_modules/@types/react') < 0;
    }
  }).parse,
  webpackConfig: require('react-scripts-ts/config/webpack.config.dev')
}
```