### PR TITLE
Accept an existing TypeScript program instance

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -53,7 +53,10 @@ export interface StaticPropFilter {
 export const defaultParserOpts: ParserOptions = {};
 
 export interface FileParser {
-  parse(filePathOrPaths: string | string[]): ComponentDoc[];
+  parse(
+    filePathOrPaths: string | string[],
+    programProvider?: () => ts.Program
+  ): ComponentDoc[];
 }
 
 const defaultOptions: ts.CompilerOptions = {
@@ -121,11 +124,17 @@ export function withCompilerOptions(
   parserOpts: ParserOptions = defaultParserOpts
 ): FileParser {
   return {
-    parse(filePathOrPaths: string | string[]): ComponentDoc[] {
+    parse(
+      filePathOrPaths: string | string[],
+      programProvider?: () => ts.Program
+    ): ComponentDoc[] {
       const filePaths = Array.isArray(filePathOrPaths)
         ? filePathOrPaths
         : [filePathOrPaths];
-      const program = ts.createProgram(filePaths, compilerOptions);
+
+      const program = programProvider
+        ? programProvider()
+        : ts.createProgram(filePaths, compilerOptions);
 
       const parser = new Parser(program, parserOpts);
 


### PR DESCRIPTION
Thank you for maintaining this package. It's finding use in more and more places.

This change allows the parser to accept an existing instance of `ts.Program`. This is useful to allow outside libraries to implement language service integration or caching for performance improvements.

I'm not sure of the test is a bit overdone for something like this. Let me know if any changes are needed.