### PR TITLE
General API for overriding component names

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ propsParser: require('react-docgen-typescript').withCustomConfig('./tsconfig.jso
 
   Note: `children` without a doc comment will not be documented.
 
+- componentNameResolver:
+
+  ```typescript
+  (exp: ts.Symbol, source: ts.SourceFile) => string | undefined | null | false
+  ```
+
+  If a string is returned, then the component will use that name. Else it will fallback to the default logic of parser.
+
+**Styled components example:**
+
+```typescript
+componentNameResolver: (exp, source) => exp.getName() === 'StyledComponentClass' && getDefaultExportForFile(source);
+```
+
+> The parser exports `getDefaultExportForFile` helper through its public API.
+
 ## Example
 
 In the example folder you can see React Styleguidist integration.

--- a/src/__tests__/data/StatelessDisplayNameStyledComponent.tsx
+++ b/src/__tests__/data/StatelessDisplayNameStyledComponent.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export interface StyledComponentClassProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** Stateless description */
+const StyledComponentClass: React.SFC<StyledComponentClassProps> = props => (
+  <div>My Property = {props.myProp}</div>
+);
+
+// If we had a styled component, it would emit StyledComponentClass
+// by default.
+export default StyledComponentClass;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -532,6 +532,13 @@ describe('parser', () => {
       assert.equal(parsed.displayName, 'StatelessDisplayNameDefaultExport');
     });
 
+    it('should be taken from filename for styled components', () => {
+      const [parsed] = parse(
+        fixturePath('StatelessDisplayNameStyledComponent')
+      );
+      assert.equal(parsed.displayName, 'StatelessDisplayNameStyledComponent');
+    });
+
     it('should be taken from stateful component `displayName` property (using default export)', () => {
       const [parsed] = parse(fixturePath('StatefulDisplayNameDefaultExport'));
       assert.equal(parsed.displayName, 'StatefulDisplayNameDefaultExport');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -665,6 +665,7 @@ function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
   if (
     exportName === 'default' ||
     exportName === '__function' ||
+    exportName === 'StyledComponentClass' ||
     exportName === 'StatelessComponent'
   ) {
     // Default export for a file: named after file


### PR DESCRIPTION
This PR adds `componentNameResolver` and `getDefaultExportForFile` helpers for writing custom component name resolvers (important for styled components and such).