### PR TITLE
fix: Expose getDefaultExportForFile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
   ComponentDoc,
   FileParser,
+  getDefaultExportForFile,
   parse,
   ParserOptions,
   PropItem,
@@ -13,6 +14,7 @@ import {
 
 export {
   parse,
+  getDefaultExportForFile,
   withCompilerOptions,
   withDefaultConfig,
   withCustomConfig,


### PR DESCRIPTION
Forgot to do this earlier. Now the helper is exposed correctly.