### PR TITLE
fix typo (decalarations -> declarations)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -688,14 +688,14 @@ export function getDefaultExportForFile(source: ts.SourceFile) {
 }
 
 function getParentType(prop: ts.Symbol): ParentType | undefined {
-  const decalarations = prop.getDeclarations();
+  const declarations = prop.getDeclarations();
 
-  if (decalarations == null || decalarations.length === 0) {
+  if (declarations == null || declarations.length === 0) {
     return undefined;
   }
 
   // Props can be declared only in one place
-  const { parent } = decalarations[0];
+  const { parent } = declarations[0];
 
   if (!isInterfaceOrTypeAliasDeclaration(parent)) {
     return undefined;


### PR DESCRIPTION
Just a simple typo fix before I start digging into [Issue #132](https://github.com/styleguidist/react-docgen-typescript/issues/132)