### PR TITLE
Determine parent fileNames relative to the current directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-typescript",
-  "version": "1.8.1",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -227,6 +227,26 @@ describe('parser', () => {
     });
   });
 
+  // see issue #132 (https://github.com/styleguidist/react-docgen-typescript/issues/132)
+  it('should determine the parent fileName relative to the project directory', () => {
+    check(
+      'ExportsPropTypeImport',
+      {
+        ExportsPropTypes: {
+          foo: {
+            parent: {
+              fileName:
+                'react-docgen-typescript/src/__tests__/data/ExportsPropTypeImport.tsx',
+              name: 'ExportsPropTypesProps'
+            },
+            type: 'any'
+          } as any
+        }
+      },
+      true
+    );
+  });
+
   describe('component with default props', () => {
     const expectation = {
       ComponentWithDefaultProps: {
@@ -799,10 +819,9 @@ describe('parser', () => {
       const [parsed] = parse(
         fixturePath('StatelessDisplayNameStyledComponent'),
         {
-          componentNameResolver: (exp, source) => (
+          componentNameResolver: (exp, source) =>
             exp.getName() === 'StyledComponentClass' &&
             getDefaultExportForFile(source)
-          )
         }
       );
       assert.equal(parsed.displayName, 'StatelessDisplayNameStyledComponent');

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -20,6 +20,10 @@ export interface ExpectedProp {
   required?: boolean;
   description?: string;
   defaultValue?: string | null;
+  parent?: {
+    name: string;
+    fileName: string;
+  };
 }
 
 export function fixturePath(componentName: string) {
@@ -125,6 +129,21 @@ export function checkComponent(
             // tslint:disable-next-line:max-line-length
             `Property '${compName}.${expectedPropName}' description is different - expected: ${expectedDescription}, actual: ${
               prop.description
+            }`
+          );
+        }
+        const expectedParentFileName = expectedProp.parent
+          ? expectedProp.parent.fileName
+          : undefined;
+        if (
+          expectedParentFileName &&
+          prop.parent &&
+          expectedParentFileName !== prop.parent.fileName
+        ) {
+          errors.push(
+            // tslint:disable-next-line:max-line-length
+            `Property '${compName}.${expectedPropName}' parent fileName is different - expected: ${expectedParentFileName}, actual: ${
+              prop.parent.fileName
             }`
           );
         }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,7 +6,7 @@ import { buildFilter } from './buildFilter';
 
 // We'll use the currentDirectoryName to trim parent fileNames
 const currentDirectoryPath = process.cwd();
-const currentDirectoryParts = currentDirectoryPath.split('/');
+const currentDirectoryParts = currentDirectoryPath.split(path.sep);
 const currentDirectoryName =
   currentDirectoryParts[currentDirectoryParts.length - 1];
 export interface StringIndexedObject<T> {
@@ -711,7 +711,7 @@ function getParentType(prop: ts.Symbol): ParentType | undefined {
   const parentName = parent.name.text;
   const { fileName } = parent.getSourceFile();
 
-  const fileNameParts = fileName.split('/');
+  const fileNameParts = fileName.split(path.sep);
   const trimmedFileNameParts = fileNameParts.slice();
 
   while (trimmedFileNameParts.length) {
@@ -722,7 +722,7 @@ function getParentType(prop: ts.Symbol): ParentType | undefined {
   }
   let trimmedFileName;
   if (trimmedFileNameParts.length) {
-    trimmedFileName = trimmedFileNameParts.join('/');
+    trimmedFileName = trimmedFileNameParts.join(path.sep);
   } else {
     trimmedFileName = fileName;
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,6 +4,11 @@ import * as ts from 'typescript';
 
 import { buildFilter } from './buildFilter';
 
+// We'll use the currentDirectoryName to trim parent fileNames
+const currentDirectoryPath = process.cwd();
+const currentDirectoryParts = currentDirectoryPath.split('/');
+const currentDirectoryName =
+  currentDirectoryParts[currentDirectoryParts.length - 1];
 export interface StringIndexedObject<T> {
   [key: string]: T;
 }
@@ -41,7 +46,10 @@ export interface ParentType {
 
 export type PropFilter = (props: PropItem, component: Component) => boolean;
 
-export type ComponentNameResolver = (exp: ts.Symbol, source: ts.SourceFile) => string | undefined | null | false;
+export type ComponentNameResolver = (
+  exp: ts.Symbol,
+  source: ts.SourceFile
+) => string | undefined | null | false;
 
 export interface ParserOptions {
   propFilter?: StaticPropFilter | PropFilter;
@@ -209,7 +217,8 @@ class Parser {
 
     if (propsType) {
       const resolvedComponentName = componentNameResolver(exp, source);
-      const componentName = resolvedComponentName || computeComponentName(exp, source);
+      const componentName =
+        resolvedComponentName || computeComponentName(exp, source);
       const defaultProps = this.extractDefaultPropsFromComponent(exp, source);
       const props = this.getPropsInfo(propsType, defaultProps);
 
@@ -672,7 +681,7 @@ function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
     exportName === '__function' ||
     exportName === 'StatelessComponent'
   ) {
-    return  getDefaultExportForFile(source);
+    return getDefaultExportForFile(source);
   } else {
     return exportName;
   }
@@ -680,11 +689,9 @@ function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
 
 // Default export for a file: named after file
 export function getDefaultExportForFile(source: ts.SourceFile) {
-    const name = path.basename(source.fileName, path.extname(source.fileName));
+  const name = path.basename(source.fileName, path.extname(source.fileName));
 
-    return name === 'index'
-      ? path.basename(path.dirname(source.fileName))
-      : name;
+  return name === 'index' ? path.basename(path.dirname(source.fileName)) : name;
 }
 
 function getParentType(prop: ts.Symbol): ParentType | undefined {
@@ -704,8 +711,24 @@ function getParentType(prop: ts.Symbol): ParentType | undefined {
   const parentName = parent.name.text;
   const { fileName } = parent.getSourceFile();
 
+  const fileNameParts = fileName.split('/');
+  const trimmedFileNameParts = fileNameParts.slice();
+
+  while (trimmedFileNameParts.length) {
+    if (trimmedFileNameParts[0] === currentDirectoryName) {
+      break;
+    }
+    trimmedFileNameParts.splice(0, 1);
+  }
+  let trimmedFileName;
+  if (trimmedFileNameParts.length) {
+    trimmedFileName = trimmedFileNameParts.join('/');
+  } else {
+    trimmedFileName = fileName;
+  }
+
   return {
-    fileName,
+    fileName: trimmedFileName,
     name: parentName
   };
 }
@@ -754,7 +777,13 @@ function parseWithProgramProvider(
         docs,
         checker
           .getExportsOfModule(moduleSymbol)
-          .map(exp => parser.getComponentInfo(exp, sourceFile, parserOpts.componentNameResolver))
+          .map(exp =>
+            parser.getComponentInfo(
+              exp,
+              sourceFile,
+              parserOpts.componentNameResolver
+            )
+          )
           .filter((comp): comp is ComponentDoc => comp !== null)
           .filter((comp, index, comps) =>
             comps


### PR DESCRIPTION
Resolves Issue #132 - Absolute file paths ruin our git diffs

List of changes:
- Parent filename is scanned for current directory name and trimmed to paths following that (inclusive)
- If the current directory name is never found we fallback to the full path (can assume that the path starts below current directory or in a different structure altogether)
- Added a parser test - `it should determine the parent fileName relative to the project directory`
- Added a `parent.fileName` comparison to `checkComponent`