### PR TITLE
fix(parser): Fix enum default values #86

### DIFF
--- a/src/__tests__/data/StatelessWithDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithDefaultProps.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
 
+export enum enumSample {
+  HELLO = 'hi',
+  BYE = 'bye'
+}
+
 /** StatelessWithDefaultProps props */
 export interface StatelessWithDefaultPropsProps {
   /**
@@ -11,6 +16,8 @@ export interface StatelessWithDefaultPropsProps {
   sampleTrue?: boolean;
   /** sampleFalse description */
   sampleFalse?: boolean;
+  /** sampleEnum description */
+  sampleEnum?: enumSample;
   /** sampleString description */
   sampleString?: string;
   /** sampleObject description */
@@ -29,6 +36,7 @@ export const StatelessWithDefaultProps: React.StatelessComponent<
 > = props => <div>test</div>;
 
 StatelessWithDefaultProps.defaultProps = {
+  sampleEnum: enumSample.HELLO,
   sampleFalse: false,
   sampleNull: null,
   sampleNumber: -1,

--- a/src/__tests__/data/StatelessWithReferencedDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithReferencedDefaultProps.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
 
+export enum enumSample {
+  HELLO = 'hi',
+  BYE = 'bye'
+}
+
 /** StatelessWithDefaultProps props */
 export interface StatelessWithDefaultPropsProps {
   /**
@@ -11,6 +16,8 @@ export interface StatelessWithDefaultPropsProps {
   sampleTrue?: boolean;
   /** sampleFalse description */
   sampleFalse?: boolean;
+  /** sampleEnum description */
+  sampleEnum?: enumSample;
   /** sampleString description */
   sampleString?: string;
   /** sampleObject description */
@@ -24,6 +31,7 @@ export interface StatelessWithDefaultPropsProps {
 }
 
 const defaultProps: Partial<StatelessWithDefaultPropsProps> = {
+  sampleEnum: enumSample.HELLO,
   sampleFalse: false,
   sampleNull: null,
   sampleNumber: -1,

--- a/src/__tests__/data/StatelessWithSpreadDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithSpreadDefaultProps.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
 
+export enum enumSample {
+  HELLO = 'hi',
+  BYE = 'bye'
+}
+
 /** StatelessWithDefaultProps props */
 export interface StatelessWithDefaultPropsProps {
   /**
@@ -11,6 +16,8 @@ export interface StatelessWithDefaultPropsProps {
   sampleTrue?: boolean;
   /** sampleFalse description */
   sampleFalse?: boolean;
+  /** sampleEnum description */
+  sampleEnum?: enumSample;
   /** sampleString description */
   sampleString?: string;
   /** sampleObject description */
@@ -38,6 +45,7 @@ StatelessWithDefaultProps.defaultProps = {
   ...defaultProps,
   // prettier-ignore
   sampleObject: { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
+  sampleEnum: enumSample.HELLO,
   sampleString: 'hello',
   sampleTrue: true,
   sampleUndefined: undefined

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -365,6 +365,11 @@ describe('parser', () => {
           required: true,
           type: '"hello" | "goodbye"'
         },
+        sampleEnum: {
+          defaultValue: 'enumSample.HELLO',
+          required: false,
+          type: 'enumSample'
+        },
         sampleFalse: {
           defaultValue: 'false',
           required: false,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -502,6 +502,8 @@ class Parser {
 
     // Literal values
     switch (initializer.kind) {
+      case ts.SyntaxKind.PropertyAccessExpression:
+        return initializer.getText();
       case ts.SyntaxKind.FalseKeyword:
         return 'false';
       case ts.SyntaxKind.TrueKeyword:


### PR DESCRIPTION
**Fixes #86.**

When setting a default value for a prop with type `enum`, `defaultValue` was being returned as `null`. Upon further investigation the switch statement in `parser.getLiteralValueFromPropertyAssignment` was not handling the case where the prop type was an `enum`.


Before:
![image](https://user-images.githubusercontent.com/558671/46573625-16bafb00-c966-11e8-88ac-45d9a2814fc5.png)


After:
![image](https://user-images.githubusercontent.com/558671/46573623-03a82b00-c966-11e8-9bf5-ebb089e18d2c.png)


