### PR TITLE
fix: allow empty description [WIP]

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -252,7 +252,7 @@ export class Parser {
         methods,
         props
       };
-    } else if (description && displayName) {
+    } else if (displayName) {
       return {
         description,
         displayName,


### PR DESCRIPTION
Can't find such component:

```tsx
export class Button extends React.Component {
  // ...
}
```

 because no comments are provided, so `description` is an empty string.