### PR TITLE
Fix filename to js identifier conversion

### DIFF
--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -895,4 +895,24 @@ describe('parser', () => {
       assert.equal(Boolean(methods.find((method => method.name === 'myPrivateFunction'))), false);
     });
   });
+
+  describe('getDefaultExportForFile', () => {
+    it('should filter out forbidden symbols', () => {
+      // @ts-ignore
+      const result = getDefaultExportForFile({ fileName: 'a-b' })
+      assert.equal(result, 'ab');
+    });
+
+    it('should remove leading non-letters', () => {
+      // @ts-ignore
+      const result = getDefaultExportForFile({ fileName: '---123aba' })
+      assert.equal(result, 'aba');
+    });
+
+    it('should not return empty string', () => {
+      // @ts-ignore
+      const result = getDefaultExportForFile({ fileName: '---123' })
+      assert.equal(result.length > 0, true);
+    });
+  });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -840,8 +840,13 @@ function computeComponentName(exp: ts.Symbol, source: ts.SourceFile) {
 // Default export for a file: named after file
 export function getDefaultExportForFile(source: ts.SourceFile) {
   const name = path.basename(source.fileName, path.extname(source.fileName));
+  const filename = name === 'index' ? path.basename(path.dirname(source.fileName)) : name;
 
-  return name === 'index' ? path.basename(path.dirname(source.fileName)) : name;
+  // JS identifiers must starts with a letter, and contain letters and/or numbers
+  // So, you could not take filename as is
+  const identifier = filename.replace(/[^A-Za-z]*|[^0-9.]*/g, '')
+
+  return identifier.length ? identifier : 'DefaultName'
 }
 
 function getParentType(prop: ts.Symbol): ParentType | undefined {


### PR DESCRIPTION
Right now it is not possible use `react-docgen-typescript` when filenames are not legal js identifiers. This pull request fixes that.