### PR TITLE
Add check to getTextValueOfFunctionProperty.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -779,6 +779,7 @@ function getTextValueOfFunctionProperty(
         .expression as ts.BinaryExpression;
       return (
         expr.left &&
+        (expr.left as ts.PropertyAccessExpression).name &&
         (expr.left as ts.PropertyAccessExpression).name.escapedText ===
           propertyName
       );


### PR DESCRIPTION
Ran into the falling issue when trying to build Storybook with the types documentation.
![screen shot 2018-12-06 at 3 56 36 pm](https://user-images.githubusercontent.com/1211360/49615781-95d7aa00-f97c-11e8-966d-14178b55ef04.png)

Adding an additional check to first see if `name` is defined kept the build from failing.
