### PR TITLE
Fix filename to js identifier conversion

### DIFF
--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -898,20 +898,30 @@ describe('parser', () => {
 
   describe('getDefaultExportForFile', () => {
     it('should filter out forbidden symbols', () => {
-      // @ts-ignore
-      const result = getDefaultExportForFile({ fileName: 'a-b' })
+      const result = getDefaultExportForFile({
+        fileName: 'a-b'
+      } as ts.SourceFile);
       assert.equal(result, 'ab');
     });
 
     it('should remove leading non-letters', () => {
-      // @ts-ignore
-      const result = getDefaultExportForFile({ fileName: '---123aba' })
+      const result = getDefaultExportForFile({
+        fileName: '---123aba'
+      } as ts.SourceFile);
       assert.equal(result, 'aba');
     });
 
+    it('should preserve numbers in the middle', () => {
+      const result = getDefaultExportForFile({
+        fileName: '1Body2Text3'
+      } as ts.SourceFile);
+      assert.equal(result, 'Body2Text3');
+    });
+
     it('should not return empty string', () => {
-      // @ts-ignore
-      const result = getDefaultExportForFile({ fileName: '---123' })
+      const result = getDefaultExportForFile({
+        fileName: '---123'
+      } as ts.SourceFile);
       assert.equal(result.length > 0, true);
     });
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -846,9 +846,11 @@ export function getDefaultExportForFile(source: ts.SourceFile) {
 
   // JS identifiers must starts with a letter, and contain letters and/or numbers
   // So, you could not take filename as is
-  const identifier = filename.replace(/[^A-Za-z]*|[^0-9.]*/g, '')
+  const identifier = filename
+    .replace(/^[^A-Z]*/gi, '')
+    .replace(/[^A-Z0-9]*/gi, '');
 
-  return identifier.length ? identifier : 'DefaultName'
+  return identifier.length ? identifier : 'DefaultName';
 }
 
 function getParentType(prop: ts.Symbol): ParentType | undefined {


### PR DESCRIPTION
Pull #157 introduced an issue where numbers aren't being preserved in the middle of an identifier.

- added new unit tests
- fixed up code to pass new tests
- fixed 'ts-ignore' lines