### PR TITLE
Include param type information when parsing method params

### DIFF
--- a/src/__tests__/data/ColumnWithMethods.tsx
+++ b/src/__tests__/data/ColumnWithMethods.tsx
@@ -30,7 +30,7 @@ export class Column extends React.Component<IColumnProps, {}> {
    * @public
    * @returns The answer to the universe
    */
-  myCoolMethod(myParam: number, mySecondParam: string): number {
+  myCoolMethod(myParam: number, mySecondParam?: string): number {
     return 42;
   }
 

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -857,12 +857,14 @@ describe('parser', () => {
         {
           description: 'Documentation for parameter 1',
           name: 'myParam',
-          type: { name: 'number', required: true }
+          type: { name: 'number' },
+          required: true
         },
         {
           description: null,
           name: 'mySecondParam',
-          type: { name: 'string', required: false }
+          type: { name: 'string' },
+          required: false
         }
       ]);
       assert.deepEqual(myCoolMethod.returns, {

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -858,13 +858,11 @@ describe('parser', () => {
           description: 'Documentation for parameter 1',
           name: 'myParam',
           type: { name: 'number' },
-          required: true
         },
         {
           description: null,
-          name: 'mySecondParam',
+          name: 'mySecondParam?',
           type: { name: 'string' },
-          required: false
         }
       ]);
       assert.deepEqual(myCoolMethod.returns, {

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -856,11 +856,13 @@ describe('parser', () => {
       assert.deepEqual(myCoolMethod.params, [
         {
           description: 'Documentation for parameter 1',
-          name: 'myParam'
+          name: 'myParam',
+          type: { name: 'number', required: true }
         },
         {
           description: null,
-          name: 'mySecondParam'
+          name: 'mySecondParam',
+          type: { name: 'string', required: false }
         }
       ]);
       assert.deepEqual(myCoolMethod.returns, {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -47,7 +47,6 @@ export interface MethodParameter {
   name: string;
   description?: string | null;
   type: MethodParameterType;
-  required: boolean;
 }
 
 export interface MethodParameterType {
@@ -411,16 +410,15 @@ export class Parser {
         param.valueDeclaration
       );
       const paramDeclaration = this.checker.symbolToParameterDeclaration(param);
-      const optionalParam = !!(paramDeclaration && paramDeclaration.questionToken);
+      const isOptionalParam: boolean = !!(paramDeclaration && paramDeclaration.questionToken);
 
       return {
         description:
           ts.displayPartsToString(
             param.getDocumentationComment(this.checker)
           ) || null,
-        name: param.getName(),
-        type: { name: this.checker.typeToString(paramType) },
-        required: !optionalParam
+        name: param.getName() + (isOptionalParam ? '?' : ''),
+        type: { name: this.checker.typeToString(paramType) }
       };
     });
   }


### PR DESCRIPTION
#145 did not include the type information for method params, and does reflect optional params with a question mark `?`.

**BEFORE** Styleguidist renders only the parameter names, not their types:
```  public focusCell(rowIdx: number, colIdx?: number): void {```
![image](https://user-images.githubusercontent.com/10970257/50941364-76c7ae80-1439-11e9-8e19-737ab786d40e.png)

**AFTER** Styleguidist renders the type names correctly:
![image](https://user-images.githubusercontent.com/10970257/50996917-22bfd700-14d8-11e9-87bf-f42234cce863.png)

I Don't Know What I'm Doing wrt Stylguidist, really, so if there's anything else I need to update, version number that needs to be bumped, etc. etc.