### PR TITLE
TypeError: Cannot read property 'escapedText' of undefined

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -736,7 +736,7 @@ function statementIsStateless(statement: ts.Statement): boolean {
     const { left } = child as ts.BinaryExpression;
     if (left) {
       const { name } = left as ts.PropertyAccessExpression;
-      if (name.escapedText === 'defaultProps') {
+      if (name && name.escapedText === 'defaultProps') {
         return true;
       }
     }


### PR DESCRIPTION
fix TypeError: Cannot read property 'escapedText' of undefined