### PR TITLE
feat: extract literal values from enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ propsParser: require('react-docgen-typescript').withCustomConfig('./tsconfig.jso
   ```
 
   If a string is returned, then the component will use that name. Else it will fallback to the default logic of parser.
+  
+- shouldExtractLiteralValuesFromEnum: boolean
+  
+  If set to true, string enums and unions will be converted to docgen enum format. Useful if you use Storybook and want to generate knobs automatically using [addon-smart-knobs](https://github.com/storybookjs/addon-smart-knobs).
 
 **Styled components example:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-typescript",
-  "version": "1.12.5",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,6 +17,12 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.3.tgz",
       "integrity": "sha512-f5dXGzOJycyzSMdaXVhiBhauL4dYydXwVpavfQ1mVCaGjR56a9QfklXObUxlIY9bGTmCPHEEZ04I16BZ/8w5ww==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.137",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.137.tgz",
+      "integrity": "sha512-g4rNK5SRKloO+sUGbuO7aPtwbwzMgjK+bm9BBhLD7jGUiGR7zhwYEhSln/ihgYQBeIJ5j7xjyaYzrWTcu3UotQ==",
       "dev": true
     },
     "@types/mocha": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "tsc": "tsc",
+    "tsc:watch": "tsc -w",
     "prepublishOnly": "tsc -d",
     "test": "tsc && mocha --timeout 10000 ./lib/**/__tests__/**.js",
     "test:debug": "tsc && mocha --debug ./lib/**/__tests__/**.js",
@@ -24,6 +25,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/chai": "^4.1.0",
+    "@types/lodash": "^4.14.137",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.5.6",
     "@types/prop-types": "^15.5.4",
@@ -32,6 +34,7 @@
     "chai": "^4.1.2",
     "husky": "^0.14.3",
     "lint-staged": "^7.3.0",
+    "lodash": "^4.17.15",
     "mocha": "^5.2.0",
     "prettier": "^1.10.2",
     "prop-types": "^15.6.2",

--- a/src/__tests__/data/ExtractLiteralValuesFromEnum.tsx
+++ b/src/__tests__/data/ExtractLiteralValuesFromEnum.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+enum sampleEnum {
+  ONE = 'one',
+  TWO = 'two',
+  THREE = 'three'
+}
+
+interface ExtractLiteralValuesFromEnumProps {
+  /** sampleString description */
+  sampleString: string;
+  /** sampleBoolean description */
+  sampleBoolean: boolean;
+  /** sampleEnum description */
+  sampleEnum: sampleEnum;
+  /** sampleStringUnion description */
+  sampleStringUnion: 'string1' | 'string2';
+  /** sampleComplexUnion description */
+  sampleComplexUnion: number | 'string1' | 'string2';
+}
+
+export const Stateless: React.StatelessComponent<
+  ExtractLiteralValuesFromEnumProps
+> = props => <div>test</div>;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -765,6 +765,40 @@ describe('parser', () => {
         });
       });
     });
+
+    describe('Extracting literal values from enums', () => {
+      it('extracts literal values from enum', () => {
+        check(
+          'ExtractLiteralValuesFromEnum',
+          {
+            ExtractLiteralValuesFromEnum: {
+              sampleBoolean: { type: 'boolean' },
+              sampleComplexUnion: { type: 'number | "string1" | "string2"' },
+              sampleEnum: {
+                raw: 'sampleEnum',
+                type: 'enum',
+                value: [
+                  { value: '"one"' },
+                  { value: '"two"' },
+                  { value: '"three"' }
+                ]
+              },
+              sampleString: { type: 'string' },
+              sampleStringUnion: {
+                raw: '"string1" | "string2"',
+                type: 'enum',
+                value: [{ value: '"string1"' }, { value: '"string2"' }]
+              }
+            }
+          },
+          true,
+          null,
+          {
+            shouldExtractLiteralValuesFromEnum: true
+          }
+        );
+      });
+    });
   });
 
   describe('withCustomConfig', () => {

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import * as path from 'path';
+import { isEqual } from 'lodash';
 import {
   ComponentDoc,
   defaultParserOpts,
@@ -24,6 +25,8 @@ export interface ExpectedProp {
     name: string;
     fileName: string;
   };
+  raw?: string;
+  value?: any;
 }
 
 export function fixturePath(componentName: string) {
@@ -170,6 +173,24 @@ export function checkComponent(
           errors.push(
             // tslint:disable-next-line:max-line-length
             `Property '${compName}.${expectedPropName}' defaultValue is different - expected: ${expectedDefaultValue}, actual: ${actualDefaultValue}`
+          );
+        }
+        const exptectedRaw = expectedProp.raw;
+        if (exptectedRaw && exptectedRaw !== prop.type.raw) {
+          // tslint:disable-next-line:max-line-length
+          errors.push(
+            `Property '${compName}.${expectedPropName}' raw value is different - expected: ${exptectedRaw}, actual: ${
+              prop.type.raw
+            }`
+          );
+        }
+        const expectedValue = expectedProp.value;
+        if (expectedValue && !isEqual(expectedValue, prop.type.value)) {
+          // tslint:disable-next-line:max-line-length
+          errors.push(
+            `Property '${compName}.${expectedPropName}' value is different - expected: ${JSON.stringify(
+              expectedValue
+            )}, actual: ${JSON.stringify(prop.type.value)}`
           );
         }
       }


### PR DESCRIPTION
Added option to convert typescript enums to unions of their values.
See [corresponding test](https://github.com/styleguidist/react-docgen-typescript/pull/201/files#diff-c4e2044ddda57c0b9b40f972fc77d27eR769) for example of usage and resulting docgen.

**Reason for adding this option:**
We are using react-docgen-typescript with Storybook to generate docgen info about components. And then we are using addon-smart-knobs to generate knobs automatically based on generated docgen. Currently we are able to generate select knobs automatically for string unions but to generate selects for enums we need to convert them to their actual string values.