### PR TITLE
fix: name variable  check to avoid build fail

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -804,7 +804,7 @@ function statementIsStatelessWithDefaultProps(
     const { left } = child as ts.BinaryExpression;
     if (left) {
       const { name } = left as ts.PropertyAccessExpression;
-      if (name.escapedText === 'defaultProps') {
+      if (name && name.escapedText === 'defaultProps') {
         return true;
       }
     }


### PR DESCRIPTION
in cases where the name is `undefined` build will fail.