### PR TITLE
feat: added flag to return default value not only as string type

### DIFF
--- a/src/__tests__/data/StatelessWithDefaultPropsAsString.tsx
+++ b/src/__tests__/data/StatelessWithDefaultPropsAsString.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+/** StatelessWithDefaultProps props */
+export interface StatelessWithDefaultPropsAsStringProps {
+  /** sampleTrue description */
+  sampleTrue?: boolean;
+  /** sampleFalse description */
+  sampleFalse?: boolean;
+  /** sampleNumberWithPrefix description */
+  sampleNumberWithPrefix?: number;
+  /** sampleNumber description */
+  sampleNumber?: number;
+  /** sampleNull description */
+  sampleNull?: null;
+  /** sampleUndefined description */
+  sampleUndefined?: undefined;
+}
+
+export const StatelessWithDefaultPropsAsString: React.StatelessComponent<
+  StatelessWithDefaultPropsAsStringProps
+> = props => <div>test</div>;
+
+StatelessWithDefaultPropsAsString.defaultProps = {
+  sampleFalse: false,
+  sampleNumberWithPrefix: -1,
+  sampleNumber: 1,
+  sampleTrue: true,
+  sampleNull: null,
+  sampleUndefined: undefined
+};

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -267,12 +267,12 @@ describe('parser', () => {
           type: '"hello" | "goodbye"'
         },
         sampleFalse: {
-          defaultValue: 'false',
+          defaultValue: false,
           required: false,
           type: 'boolean'
         },
-        sampleNull: { type: 'null', required: false, defaultValue: 'null' },
-        sampleNumber: { type: 'number', required: false, defaultValue: '-1' },
+        sampleNull: { type: 'null', required: false, defaultValue: null },
+        sampleNumber: { type: 'number', required: false, defaultValue: -1 },
         sampleObject: {
           defaultValue: `{ a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } }`,
           required: false,
@@ -283,7 +283,7 @@ describe('parser', () => {
           required: false,
           type: 'string'
         },
-        sampleTrue: { type: 'boolean', required: false, defaultValue: 'true' },
+        sampleTrue: { type: 'boolean', required: false, defaultValue: true },
         sampleUndefined: {
           defaultValue: 'undefined',
           required: false,
@@ -401,12 +401,12 @@ describe('parser', () => {
           type: 'enumSample'
         },
         sampleFalse: {
-          defaultValue: 'false',
+          defaultValue: false,
           required: false,
           type: 'boolean'
         },
-        sampleNull: { type: 'null', required: false, defaultValue: 'null' },
-        sampleNumber: { type: 'number', required: false, defaultValue: '-1' },
+        sampleNull: { type: 'null', required: false, defaultValue: null },
+        sampleNumber: { type: 'number', required: false, defaultValue: -1 },
         sampleObject: {
           defaultValue: `{ a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } }`,
           required: false,
@@ -417,9 +417,9 @@ describe('parser', () => {
           required: false,
           type: 'string'
         },
-        sampleTrue: { type: 'boolean', required: false, defaultValue: 'true' },
+        sampleTrue: { type: 'boolean', required: false, defaultValue: true },
         sampleUndefined: {
-          defaultValue: 'undefined',
+          defaultValue: undefined,
           required: false,
           type: 'any'
         }
@@ -446,7 +446,7 @@ describe('parser', () => {
             type: 'string'
           },
           shorthandProp: {
-            defaultValue: '123',
+            defaultValue: 123,
             description: 'shorthandProp description',
             required: false,
             type: 'number'
@@ -799,6 +799,53 @@ describe('parser', () => {
           null,
           {
             shouldExtractLiteralValuesFromEnum: true
+          }
+        );
+      });
+    });
+
+    describe('Returning not string default props ', () => {
+      it('returns not string defaultProps', () => {
+        check(
+          'StatelessWithDefaultPropsAsString',
+          {
+            StatelessWithDefaultPropsAsString: {
+              sampleFalse: {
+                defaultValue: 'false',
+                required: false,
+                type: 'boolean'
+              },
+              sampleNumberWithPrefix: {
+                type: 'number',
+                required: false,
+                defaultValue: '-1'
+              },
+              sampleNumber: {
+                type: 'number',
+                required: false,
+                defaultValue: '1'
+              },
+              sampleTrue: {
+                type: 'boolean',
+                required: false,
+                defaultValue: 'true'
+              },
+              sampleNull: {
+                type: 'null',
+                required: false,
+                defaultValue: 'null'
+              },
+              sampleUndefined: {
+                type: 'undefined',
+                required: false,
+                defaultValue: 'undefined'
+              }
+            }
+          },
+          true,
+          null,
+          {
+            savePropValueAsString: true
           }
         );
       });

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -20,7 +20,7 @@ export interface ExpectedProp {
   type: string;
   required?: boolean;
   description?: string;
-  defaultValue?: string | null;
+  defaultValue?: string | number | boolean | null | undefined;
   parent?: {
     name: string;
     fileName: string;


### PR DESCRIPTION
Hi! I added a flag to parser can return default value not only as string type. I don't know, maybe flag is overhead and I can do this case is a default?