### PR TITLE
Fix broken unit test in windows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,27 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: install dependencies
+      run: npm install
+      env:
+        CI: true
+    - name: test
+      run: npm test
+      env:
+        CI: true

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -977,7 +977,7 @@ function getParentType(prop: ts.Symbol): ParentType | undefined {
   const parentName = parent.name.text;
   const { fileName } = parent.getSourceFile();
 
-  const fileNameParts = fileName.split(path.sep);
+  const fileNameParts = fileName.split('/');
   const trimmedFileNameParts = fileNameParts.slice();
 
   while (trimmedFileNameParts.length) {
@@ -988,7 +988,7 @@ function getParentType(prop: ts.Symbol): ParentType | undefined {
   }
   let trimmedFileName;
   if (trimmedFileNameParts.length) {
-    trimmedFileName = trimmedFileNameParts.join(path.sep);
+    trimmedFileName = trimmedFileNameParts.join('/');
   } else {
     trimmedFileName = fileName;
   }


### PR DESCRIPTION
The current unit tests show that the parent.fileName test fails in windows.

This is because the code currently assumes the returned fileName from `getSourceFile` is a path separated based on OS separator, but in fact it is always '/' separated regardless if it is in Windows or Unix.

## Issue Reproduction

You can refer to this [GitHub Actions Log](https://github.com/malcolm-kee/react-docgen-typescript/pull/1/checks?check_run_id=271997510#step:5:58).

Note: I added GitHub Actions config just to show the failure. Let me know if you want me to remove it from the PR.