### PR TITLE
handle generic intersection

### DIFF
--- a/src/__tests__/data/StatelessIntersectionGenericProps.tsx
+++ b/src/__tests__/data/StatelessIntersectionGenericProps.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export type StatelessProps<
+  T extends React.JSXElementConstructor<any>
+> = React.ComponentProps<T> & {
+  /** myProp description */
+  myProp: string;
+};
+
+/** StatelessIntersectionGenericProps description */
+export const StatelessIntersectionGenericProps = <
+  T extends React.JSXElementConstructor<any>
+>(
+  props: StatelessProps<T>
+) => <div />;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -359,6 +359,14 @@ describe('parser', () => {
     });
   });
 
+  it('should parse react stateless component with generic intersection props', () => {
+    check('StatelessIntersectionGenericProps', {
+      StatelessIntersectionGenericProps: {
+        myProp: { type: 'string' }
+      }
+    });
+  });
+
   it('should parse react stateful component with intersection props', () => {
     check('StatefulIntersectionProps', {
       StatefulIntersectionProps: {


### PR DESCRIPTION
When trying to generate the props for the following structure I was getting nothing

```ts
export type StatelessProps<
  T extends React.JSXElementConstructor<any>
> = React.ComponentProps<T> & {
  /** myProp description */
  myProp: string;
};

/** StatelessIntersectionGenericProps description */
export const StatelessIntersectionGenericProps = <
  T extends React.JSXElementConstructor<any>
>(
  props: StatelessProps<T>
) => <div />;
```

While other intersections are correctly handled, the generic version would return nothing from `getProperties`. So I just looped through the types in the intersection and call `getProperties` on each.

With my changes my generic components are now successfully generating the props table.

fixes #203