### PR TITLE
handle more complex intersection/union props

### DIFF
--- a/src/__tests__/data/ComplexGenericUnionIntersection.tsx
+++ b/src/__tests__/data/ComplexGenericUnionIntersection.tsx
@@ -1,0 +1,23 @@
+interface StackBaseProps<T> {
+  as: T;
+  hasWrap?: boolean;
+}
+
+interface StackJustifyProps {
+  foo?: 'blue';
+  /** You cannot use gap when using a "space" justify property */
+  gap?: never;
+}
+
+interface StackGapProps {
+  foo?: 'red';
+  /** The space between children */
+  gap?: number;
+}
+
+type StackProps<T> = StackBaseProps<T> & (StackGapProps | StackJustifyProps);
+
+/** ComplexGenericUnionIntersection description */
+export const ComplexGenericUnionIntersection = <T extends any>(
+  props: StackProps<T>
+) => <div />;

--- a/src/__tests__/data/ComplexGenericUnionIntersection.tsx
+++ b/src/__tests__/data/ComplexGenericUnionIntersection.tsx
@@ -4,12 +4,14 @@ interface StackBaseProps<T> {
 }
 
 interface StackJustifyProps {
+  /** The foo prop should not repeat the description */
   foo?: 'blue';
   /** You cannot use gap when using a "space" justify property */
   gap?: never;
 }
 
 interface StackGapProps {
+  /** The foo prop should not repeat the description */
   foo?: 'red';
   /** The space between children */
   gap?: number;

--- a/src/__tests__/data/SimpleDiscriminatedUnionIntersection.tsx
+++ b/src/__tests__/data/SimpleDiscriminatedUnionIntersection.tsx
@@ -1,0 +1,9 @@
+type StackProps = { foo: string } & (
+  | { bar: 'one'; test: number }
+  | { bar: 'other'; baz: number }
+);
+
+/** SimpleDiscriminatedUnionIntersection description */
+export const SimpleDiscriminatedUnionIntersection = (props: StackProps) => (
+  <div />
+);

--- a/src/__tests__/data/SimpleUnionIntersection.tsx
+++ b/src/__tests__/data/SimpleUnionIntersection.tsx
@@ -1,0 +1,4 @@
+type StackProps = { foo: string } & ({ bar: string } | { baz: string });
+
+/** SimpleUnionIntersection description */
+export const SimpleUnionIntersection = (props: StackProps) => <div />;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -389,18 +389,22 @@ describe('parser', () => {
   });
 
   it('should parse react stateless component with generic intersection + union overlap props', () => {
-    check('ComplexGenericUnionIntersection', {
+    check("ComplexGenericUnionIntersection", {
       ComplexGenericUnionIntersection: {
-        as: { type: 'T', description: '' },
-        hasWrap: { type: 'boolean', description: '', required: false },
-        foo: { type: '"red" | "blue"', description: '', required: false },
+        as: { type: "T", description: "" },
+        hasWrap: { type: "boolean", description: "", required: false },
+        foo: {
+          type: '"red" | "blue"',
+          required: false,
+          description: "The foo prop should not repeat the description",
+        },
         gap: {
-          type: 'number | never',
+          type: "number | never",
           description:
             'The space between children\nYou cannot use gap when using a "space" justify property',
-          required: false
-        }
-      }
+          required: false,
+        },
+      },
     });
   });
 

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -370,9 +370,9 @@ describe('parser', () => {
   it('should parse react stateless component with intersection + union props', () => {
     check('SimpleUnionIntersection', {
       SimpleUnionIntersection: {
-        foo: { type: 'string', description: '' },
         bar: { type: 'string', description: '' },
-        baz: { type: 'string', description: '' }
+        baz: { type: 'string', description: '' },
+        foo: { type: 'string', description: '' }
       }
     });
   });
@@ -380,31 +380,32 @@ describe('parser', () => {
   it('should parse react stateless component with intersection + union overlap props', () => {
     check('SimpleDiscriminatedUnionIntersection', {
       SimpleDiscriminatedUnionIntersection: {
-        foo: { type: 'string', description: '' },
         bar: { type: '"one" | "other"', description: '' },
-        test: { type: 'number', description: '' },
-        baz: { type: 'number', description: '' }
+        baz: { type: 'number', description: '' },
+        foo: { type: 'string', description: '' },
+        test: { type: 'number', description: '' }
       }
     });
   });
 
   it('should parse react stateless component with generic intersection + union overlap props', () => {
-    check("ComplexGenericUnionIntersection", {
+    check('ComplexGenericUnionIntersection', {
       ComplexGenericUnionIntersection: {
-        as: { type: "T", description: "" },
-        hasWrap: { type: "boolean", description: "", required: false },
+        as: { type: 'T', description: '' },
         foo: {
-          type: '"red" | "blue"',
+          description:
+            'The foo prop should not repeat the description \nThe foo prop should not repeat the description',
           required: false,
-          description: "The foo prop should not repeat the description",
+          type: '"red" | "blue"'
         },
         gap: {
-          type: "number | never",
           description:
-            'The space between children\nYou cannot use gap when using a "space" justify property',
+            'The space between children \nYou cannot use gap when using a "space" justify property',
           required: false,
+          type: 'number'
         },
-      },
+        hasWrap: { type: 'boolean', description: '', required: false }
+      }
     });
   });
 

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -367,6 +367,43 @@ describe('parser', () => {
     });
   });
 
+  it('should parse react stateless component with intersection + union props', () => {
+    check('SimpleUnionIntersection', {
+      SimpleUnionIntersection: {
+        foo: { type: 'string', description: '' },
+        bar: { type: 'string', description: '' },
+        baz: { type: 'string', description: '' }
+      }
+    });
+  });
+
+  it('should parse react stateless component with intersection + union overlap props', () => {
+    check('SimpleDiscriminatedUnionIntersection', {
+      SimpleDiscriminatedUnionIntersection: {
+        foo: { type: 'string', description: '' },
+        bar: { type: '"one" | "other"', description: '' },
+        test: { type: 'number', description: '' },
+        baz: { type: 'number', description: '' }
+      }
+    });
+  });
+
+  it('should parse react stateless component with generic intersection + union overlap props', () => {
+    check('ComplexGenericUnionIntersection', {
+      ComplexGenericUnionIntersection: {
+        as: { type: 'T', description: '' },
+        hasWrap: { type: 'boolean', description: '', required: false },
+        foo: { type: '"red" | "blue"', description: '', required: false },
+        gap: {
+          type: 'number | never',
+          description:
+            'The space between children\nYou cannot use gap when using a "space" justify property',
+          required: false
+        }
+      }
+    });
+  });
+
   it('should parse react stateful component with intersection props', () => {
     check('StatefulIntersectionProps', {
       StatefulIntersectionProps: {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -553,14 +553,18 @@ export class Parser {
             : jsDocComment.fullComment;
         }
 
-        if (!stored.type.name.split(' | ').includes(type.name)) {
+        if (!stored.type) {
+          stored.type = type;
+        } else if (stored.type.name.split(' | ').indexOf(type.name) === -1) {
           stored.type.name += ` | ${this.getDocgenType(propType).name}`;
         }
 
         if (defaultValue) {
           if (!stored.defaultValue) {
             stored.defaultValue = defaultValue;
-          } else if (!stored.defaultValue.value.includes(defaultValue.value)) {
+          } else if (
+            stored.defaultValue.value.indexOf(defaultValue.value) === -1
+          ) {
             stored.defaultValue += ` | ${defaultValue}`;
           }
         }


### PR DESCRIPTION
closes #158 
closes #57 

Addresses some of #68 but that issue seems to be more about displaying separate props tables for each set of properties. 

This pull request aims to better `react-docgen-typescript`'s ability to document complex prop types. 

There were a few of these situations fixed in #241 but I missed a few cases.

### **Case 1:**

Intersection + Union

```tsx
type ExampleProps = { foo: string } & ({ bar: string } | { baz: string });

export const Example = (props: ExampleProps) => <div />;
```

*Previous:* Only `foo` received documentation
*Now:* All props receive documentation

### **Case 2:**

Discriminated Intersection + Union

```tsx
type StackProps = { foo: string } & (
  | { bar: 'one'; test: number }
  | { bar: 'other'; baz: number }
);

export const ExampleProps = (props: StackProps) => <div />
```

*Previous:* Only `foo` and `bar` received documentation
*Now:* All props receive documentation

### **Case 3:**

Complex Intersection + Union with overlapping props

```tsx
interface StackBaseProps<T> {
  as: T;
  hasWrap?: boolean;
}

interface StackJustifyProps {
  foo?: 'blue';
  /** You cannot use gap when using a "space" justify property */
  gap?: never;
}

interface StackGapProps {
  foo?: 'red';
  /** The space between children */
  gap?: number;
}

type StackProps<T> = StackBaseProps<T> & (StackGapProps | StackJustifyProps);

export const ComplexGenericUnionIntersection = <T extends any>(
  props: StackProps<T>
) => <div />;
```

*Previous:* `gap` would receive wrong type, `hasWrap` was required for some reason too. I also found some situations where the union type would be overwritten to be just blue or red
*Now:* All overlapping receive full merged documentation.