### PR TITLE
Handle components exported in an object

### DIFF
--- a/src/__tests__/data/ExportObject.tsx
+++ b/src/__tests__/data/ExportObject.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+/** Bar description */
+const Bar: React.FC<{ foo: string }> = () => <div />;
+/** FooBar description */
+const FooBar: React.FC<{ foobar: string }> = props => <div />;
+
+/** Baz description */
+function Baz(props: { baz: string }) {
+  return <div />;
+}
+
+export { Bar, Baz, FooBar };

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -341,6 +341,20 @@ describe('parser', () => {
     });
   });
 
+  it('should component where last line is a comment', () => {
+    check('ExportObject', {
+      Baz: {
+        baz: { description: '', type: 'string' }
+      },
+      Bar: {
+        foo: { description: '', type: 'string' }
+      },
+      FooBar: {
+        foobar: { description: '', type: 'string' }
+      }
+    });
+  });
+
   it('should parse react stateless component with intersection props', () => {
     check('StatelessIntersectionProps', {
       StatelessIntersectionProps: {
@@ -612,7 +626,7 @@ describe('parser', () => {
       'FunctionalComponentAsConstAsNamedExport',
       {
         // in this case the component name is taken from the file name
-        FunctionalComponentAsConstAsNamedExport: {
+        Jumbotron: {
           prop1: { type: 'string', required: true }
         }
       },
@@ -626,7 +640,7 @@ describe('parser', () => {
       'ReactSFCAsConstAsNamedExport',
       {
         // in this case the component name is taken from the file name
-        ReactSFCAsConstAsNamedExport: {
+        Jumbotron: {
           prop1: { type: 'string', required: true }
         }
       },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -231,9 +231,10 @@ export class Parser {
     );
     let commentSource = exp;
     const typeSymbol = type.symbol || type.aliasSymbol;
+    const originalName = exp.getName();
 
     if (!exp.valueDeclaration) {
-      if (exp.getName() === 'default' && !typeSymbol) {
+      if (originalName === 'default' && !typeSymbol) {
         commentSource = this.checker.getAliasedSymbol(commentSource);
       } else if (!typeSymbol) {
         return null;
@@ -242,6 +243,7 @@ export class Parser {
         const expName = exp.getName();
 
         if (
+          expName === '__function' ||
           expName === 'StatelessComponent' ||
           expName === 'Stateless' ||
           expName === 'StyledComponentClass' ||
@@ -268,9 +270,10 @@ export class Parser {
       this.extractPropsFromTypeIfStatelessComponent(type) ||
       this.extractPropsFromTypeIfStatefulComponent(type);
 
-    const resolvedComponentName = componentNameResolver(exp, source);
+    const nameSource = originalName === 'default' ? exp : commentSource;
+    const resolvedComponentName = componentNameResolver(nameSource, source);
     const displayName =
-      resolvedComponentName || computeComponentName(exp, source);
+      resolvedComponentName || computeComponentName(nameSource, source);
     const description = this.findDocComment(commentSource).fullComment;
     const methods = this.getMethodsInfo(type);
 


### PR DESCRIPTION
closes #176

I had to change the following test cases 

https://github.com/styleguidist/react-docgen-typescript/pull/253/files#diff-c4e2044ddda57c0b9b40f972fc77d27eR629
https://github.com/styleguidist/react-docgen-typescript/pull/253/files#diff-c4e2044ddda57c0b9b40f972fc77d27eR643

They were using the name of the file for the name of the component that was already a named export. Since they are named exports and aren't exported as default I think It makes more sense the way it is now. 

We could count how many exports that are, but I think the code in the PR makes more sense