### PR TITLE
fix parse error for export default interface

### DIFF
--- a/src/__tests__/data/ExportsDefaultInterface.tsx
+++ b/src/__tests__/data/ExportsDefaultInterface.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export default interface Props {
+  /** foo description */
+  foo: any;
+}
+
+/**
+ * Component description
+ */
+export const Component: React.SFC<Props> = props => <div />;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -221,6 +221,14 @@ describe('parser', () => {
     });
   });
 
+  it('should parse default interface export', () => {
+    check('ExportsDefaultInterface', {
+      Component: {
+        foo: { type: 'any' }
+      }
+    });
+  });
+
   it('should parse react component that exports a prop type const', () => {
     check('ExportsPropTypeShape', {
       ExportsPropTypes: {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -243,7 +243,11 @@ export class Parser {
     const originalName = exp.getName();
 
     if (!exp.valueDeclaration) {
-      if (originalName === 'default' && !typeSymbol) {
+      if (
+        originalName === 'default' &&
+        !typeSymbol &&
+        (exp.flags & ts.SymbolFlags.Alias) !== 0
+      ) {
         commentSource = this.checker.getAliasedSymbol(commentSource);
       } else if (!typeSymbol) {
         return null;


### PR DESCRIPTION
When `export default interface Interface {}` is used the parser currently fails with `Error: Debug Failure. False expression: Should only get Alias here` at Object.resolveAlias [as getAliasedSymbol].

It probably fails for other type only exports as well when they are used as default export. The fix makes sure only actual aliases are passed to `getAliasedSymbol`.

