### PR TITLE
feat: allow jsdoc @type to override a prop's type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-typescript",
-  "version": "1.16.3",
+  "version": "1.16.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/data/ComponentWithTypeJsDocTag.tsx
+++ b/src/__tests__/data/ComponentWithTypeJsDocTag.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+/** IComponentWithTypeJsDocTag props */
+export interface IComponentWithTypeJsDocTag {
+  /**
+   * sample with custom type
+   * @type string
+   */
+  sampleTypeFromJSDoc: number;
+}
+
+/** ComponentWithTypeJsDocTag description */
+export class ComponentWithTypeJsDocTag extends React.Component<
+  IComponentWithTypeJsDocTag,
+  {}
+> {
+  public render() {
+    return <div>test</div>;
+  }
+}

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -309,6 +309,22 @@ describe('parser', () => {
     });
   });
 
+  describe('component with @type jsdoc tag', () => {
+    const expectation = {
+      ComponentWithTypeJsDocTag: {
+        sampleTypeFromJSDoc: {
+          description: 'sample with custom type',
+          required: true,
+          type: 'string'
+        }
+      }
+    };
+
+    it('should parse defined props', () => {
+      check('ComponentWithTypeJsDocTag', expectation);
+    });
+  });
+
   it('should parse react PureComponent', () => {
     check('PureRow', {
       Row: {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -567,13 +567,19 @@ export class Parser {
         declarations.every(d => !d.questionToken) &&
         (!baseProp || !isOptional(baseProp));
 
+      const type = jsDocComment.tags.type
+        ? {
+            name: jsDocComment.tags.type
+          }
+        : this.getDocgenType(propType, required);
+
       result[propName] = {
         defaultValue,
         description: jsDocComment.fullComment,
         name: propName,
         parent,
         required,
-        type: this.getDocgenType(propType, required)
+        type
       };
     });
 
@@ -630,7 +636,7 @@ export class Parser {
         ? currentValue + '\n' + trimmedText
         : trimmedText;
 
-      if (tag.name !== 'default') {
+      if (['default', 'type'].indexOf(tag.name) < 0) {
         tagComments.push(formatTag(tag));
       }
     });


### PR DESCRIPTION
This commit allows you to use the jsdoc `@type` tag to override the resulting parsed type for a prop.
```ts
export interface IComponentWithTypeJsDocTag {
  /**
   * sample with custom type
   * @type string
   */
  sampleTypeFromJSDoc: number;
}
```

This is useful for types that are complicated or too verbose and where you can provide a  simpler type just for the docs.