### PR TITLE
document static sub-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-typescript",
-  "version": "1.16.5",
+  "version": "1.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2300,9 +2300,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react": "^16.4.2",
     "source-map-support": "^0.5.6",
     "tslint": "^5.11.0",
-    "typescript": "3.0.1"
+    "typescript": "3.1.6"
   },
   "files": [
     "lib",

--- a/src/__tests__/data/ColumnWithStaticComponents.tsx
+++ b/src/__tests__/data/ColumnWithStaticComponents.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+interface LabelProps {
+  /** title description */
+  title: string;
+}
+
+/** Column.Label description */
+const SubComponent = (props: LabelProps) => <div>My Property = {props.title}</div>;
+
+/**
+ * Column properties.
+ */
+export interface IColumnProps {
+  /** prop1 description */
+  prop1: string;
+}
+
+/**
+ * Column description
+ */
+export class Column extends React.Component<IColumnProps, {}> {
+  public static Label = SubComponent;
+
+  /** Column.SubLabel description */
+  public static SubLabel() {
+    return <div>sub</div>
+  };
+
+  public render() {
+    const { prop1 } = this.props;
+    return <div>{prop1}</div>;
+  }
+}
+
+export default Column;

--- a/src/__tests__/data/StatelessStaticComponents.tsx
+++ b/src/__tests__/data/StatelessStaticComponents.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+interface LabelProps {
+  /** title description */
+  title: string;
+}
+
+/** StatelessStaticComponents.Label description */
+const SubComponent = (props: LabelProps) => <div>My Property = {props.title}</div>;
+
+interface StatelessStaticComponentsProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** StatelessStaticComponents description */
+export const StatelessStaticComponents = (props: StatelessStaticComponentsProps) => (
+  <div>My Property = {props.myProp}</div>
+);
+
+StatelessStaticComponents.Label = SubComponent;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -94,11 +94,10 @@ describe('parser', () => {
   });
 
   it('should parse simple react class component with picked properties', () => {
-    // we are not able to get correct descriptions for prop1,prop2
     check('ColumnWithPick', {
       Column: {
-        prop1: { type: 'string', required: false, description: '' },
-        prop2: { type: 'number', description: '' },
+        prop1: { type: 'string', required: false },
+        prop2: { type: 'number' },
         propx: { type: 'number' }
       }
     });
@@ -188,6 +187,29 @@ describe('parser', () => {
       ExternalPropsComponent: {
         prop1: { type: 'string' }
       }
+    });
+  });
+
+  it('should parse static sub components', () => {
+    check('StatelessStaticComponents', {
+      StatelessStaticComponents: {
+        myProp: { type: 'string' }
+      },
+      'StatelessStaticComponents.Label': {
+        title: { type: 'string' }
+      }
+    });
+  });
+  
+  it('should parse static sub components on class components', () => {
+    check('ColumnWithStaticComponents', {
+      Column: {
+        prop1: { type: 'string' }
+      },
+      'Column.Label': {
+        title: { type: 'string' }
+      },
+      'Column.SubLabel': {}
     });
   });
 
@@ -445,13 +467,13 @@ describe('parser', () => {
         as: { type: 'T', description: '' },
         foo: {
           description:
-            'The foo prop should not repeat the description \nThe foo prop should not repeat the description',
+            'The foo prop should not repeat the description\nThe foo prop should not repeat the description',
           required: false,
           type: '"red" | "blue"'
         },
         gap: {
           description:
-            'The space between children \nYou cannot use gap when using a "space" justify property',
+            'The space between children\nYou cannot use gap when using a "space" justify property',
           required: false,
           type: 'number'
         },


### PR DESCRIPTION
Adds the ability to generate docs for static sub-components. Works in both function and class components

```tsx
import * as React from "react";

interface LabelProps {
  /** title description */
  title: string;
}

/** StatelessStaticComponents.Label description */
const SubComponent = (props: LabelProps) => <div>My Property = {props.title}</div>;

interface StatelessStaticComponentsProps {
  /** myProp description */
  myProp: string;
}

/** StatelessStaticComponents description */
export const StatelessStaticComponents = (props: StatelessStaticComponentsProps) => (
  <div>My Property = {props.myProp}</div>
);

StatelessStaticComponents.Label = SubComponent;
```

The code will construct a `displayName` from the parent component + the sub component's name.

closes #98