### PR TITLE
respect base apparentProperties in unions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@
 language: node_js
 script: npm run test
 node_js:
-  - 6
+  - 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-typescript",
-  "version": "1.19.0",
+  "version": "1.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2839,9 +2839,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "source-map-support": "^0.5.6",
-    "typescript": "3.1.6"
+    "typescript": "3.5.2"
   },
   "files": [
     "lib",

--- a/src/__tests__/data/ComplexGenericUnionIntersectionWithOmit.tsx
+++ b/src/__tests__/data/ComplexGenericUnionIntersectionWithOmit.tsx
@@ -1,0 +1,46 @@
+declare type PropsOf<
+  E extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+> = JSX.LibraryManagedAttributes<E, React.ComponentPropsWithoutRef<E>>;
+
+/** Props for a Box component that supports the "innerRef" and "as" props. */
+type BoxProps<E extends React.ElementType, P = any> = P &
+  Omit<PropsOf<E>, keyof P> & {
+    /** Render the component as another component */
+    as?: E;
+  };
+
+interface StackBaseProps {
+  /** The flex "align" property */
+  align?: 'stretch' | 'center' | 'flex-start' | 'flex-end';
+}
+
+interface StackJustifyProps {
+  /**
+   * Use flex 'space-between' | 'space-around' | 'space-evenly' and
+   * flex will space the children.
+   */
+  justify?: 'space-between' | 'space-around' | 'space-evenly';
+  /** You cannot use gap when using a "space" justify property */
+  gap?: never;
+}
+
+interface StackGapProps {
+  /**
+   * Use flex 'center' | 'flex-start' | 'flex-end' | 'stretch' with
+   * a gap between each child.
+   */
+  justify?: 'center' | 'flex-start' | 'flex-end' | 'stretch';
+  /** The space between children */
+  gap?: number | string;
+}
+
+type StackProps = StackBaseProps & (StackGapProps | StackJustifyProps);
+
+const defaultElement = 'div' as const;
+
+/** ComplexGenericUnionIntersectionWithOmit description */
+export const ComplexGenericUnionIntersectionWithOmit = <
+  E extends React.ElementType = typeof defaultElement
+>(
+  props: BoxProps<E, StackProps>
+) => <div />;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -542,6 +542,36 @@ describe('parser', () => {
     });
   });
 
+  it('should parse react stateless component with generic intersection + union + omit overlap props', () => {
+    check('ComplexGenericUnionIntersectionWithOmit', {
+      ComplexGenericUnionIntersectionWithOmit: {
+        as: {
+          type: 'E',
+          required: false,
+          description: 'Render the component as another component'
+        },
+        align: {
+          description: 'The flex "align" property',
+          required: false,
+          type: '"center" | "flex-start" | "flex-end" | "stretch"'
+        },
+        justify: {
+          description:
+            "Use flex 'center' | 'flex-start' | 'flex-end' | 'stretch' with\na gap between each child.\nUse flex 'space-between' | 'space-around' | 'space-evenly' and\nflex will space the children.",
+          required: false,
+          type:
+            '"center" | "flex-start" | "flex-end" | "stretch" | "space-between" | "space-around" | "space-evenly"'
+        },
+        gap: {
+          description:
+            'The space between children\nYou cannot use gap when using a "space" justify property',
+          required: false,
+          type: 'ReactText'
+        }
+      }
+    });
+  });
+
   it('should parse react stateful component with intersection props', () => {
     check('StatefulIntersectionProps', {
       StatefulIntersectionProps: {


### PR DESCRIPTION
Commits: 

1. Fix generic union types with an `Omit`. We weren't using the `apparentProps` before and those should be included.
  - upgraded TS version to use `as const`
2. Updated and ran prettier on everything (I was having trouble getting a minimal commit diff)
  - had to upgrade travis node version for this

