### PR TITLE
use just the description for JSDoc comment instead of full comment

### DIFF
--- a/src/__tests__/data/JSDocWithParam.tsx
+++ b/src/__tests__/data/JSDocWithParam.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+/** JSDocWithParamProps props */
+export interface JSDocWithParamProps {
+  /** prop1 description */
+  prop1: string;
+}
+
+/**
+ * JSDocWithParamProps description
+ *
+ * NOTE: If a parent element of this control is `overflow: hidden` then the
+ * balloon may not show up.
+ *
+ * @param props Control properties (defined in `SimpleDropdownProps` interface)
+ */
+export const JSDocWithParam = (props: JSDocWithParamProps) => {
+  return <div>Test</div>;
+};

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -699,6 +699,19 @@ describe('parser', () => {
     });
   });
 
+  it('should parse JSDoc correctly', () => {
+    check(
+      'JSDocWithParam',
+      {
+        JSDocWithParam: {
+          prop1: { type: 'string', required: true }
+        }
+      },
+      true,
+      'JSDocWithParamProps description\n\nNOTE: If a parent element of this control is `overflow: hidden` then the\nballoon may not show up.'
+    );
+  });
+
   it('should parse functional component component defined as const as default export', () => {
     check(
       'FunctionalComponentAsConstAsDefaultExport',

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -297,7 +297,7 @@ export class Parser {
     const resolvedComponentName = componentNameResolver(nameSource, source);
     const displayName =
       resolvedComponentName || computeComponentName(nameSource, source);
-    const description = this.findDocComment(commentSource).fullComment;
+    const { description } = this.findDocComment(commentSource);
     const methods = this.getMethodsInfo(type);
 
     if (propsType) {


### PR DESCRIPTION
Instead of using the full comment for the component we use just the description instead.

closes #133