### PR TITLE
follow default props that are PropertyAccessExpressions

### DIFF
--- a/src/__tests__/data/SeparateDefaultProps.tsx
+++ b/src/__tests__/data/SeparateDefaultProps.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+const defaultProps = {
+  id: 123,
+  disabled: false
+};
+
+interface SeparateDefaultPropsProps {
+  id: number;
+  disabled: boolean;
+}
+
+/** SeparateDefaultProps description */
+export const SeparateDefaultProps = (props: SeparateDefaultPropsProps) => (
+  <div>test</div>
+);
+
+SeparateDefaultProps.defaultProps = defaultProps;

--- a/src/__tests__/data/SeparateDefaultPropsIndividual.tsx
+++ b/src/__tests__/data/SeparateDefaultPropsIndividual.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+const defaultProps2 = {
+  id: 123
+};
+
+const defaultProps = {
+  id: defaultProps2.id,
+  disabled: false
+};
+
+interface SeparateDefaultPropsIndividualProps {
+  id: number;
+  disabled: boolean;
+}
+
+/** SeparateDefaultPropsIndividual description */
+export const SeparateDefaultPropsIndividual = (
+  props: SeparateDefaultPropsIndividualProps
+) => <div>test</div>;
+
+SeparateDefaultPropsIndividual.defaultProps = {
+  id: defaultProps.id,
+  disabled: defaultProps.disabled
+};

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -982,6 +982,44 @@ describe('parser', () => {
       });
     });
 
+    it('should defaultProps in variable', () => {
+      check('SeparateDefaultProps', {
+        SeparateDefaultProps: {
+          disabled: {
+            description: '',
+            required: false,
+            defaultValue: false,
+            type: 'boolean'
+          },
+          id: {
+            description: '',
+            required: false,
+            defaultValue: 123,
+            type: 'number'
+          }
+        }
+      });
+    });
+
+    it('should defaultProps accessed variable', () => {
+      check('SeparateDefaultPropsIndividual', {
+        SeparateDefaultPropsIndividual: {
+          disabled: {
+            description: '',
+            required: false,
+            defaultValue: false,
+            type: 'boolean'
+          },
+          id: {
+            description: '',
+            required: false,
+            defaultValue: 123,
+            type: 'number'
+          }
+        }
+      });
+    });
+
     describe('Extracting literal values from enums', () => {
       it('extracts literal values from enum', () => {
         check(


### PR DESCRIPTION
fixes #233 (default props in a variable)

Also fixes issue where you access properties from and object 

```js
const defaults = { id: 123 }

MyComponent.defaultProps = {
  id: defaults.id
}
```