### PR TITLE
add skipChildrenPropWithoutDoc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ If set to true, string enums and unions will be converted to docgen enum format.
 
 If set to true, every unions will be converted to docgen enum format.
 
+### `skipChildrenPropWithoutDoc`: boolean (default: `true`)
+
+If set to false the docs for the `children` prop will be generated even without an explicit description.
+
 ### `shouldRemoveUndefinedFromOptional`: boolean
 
 If set to true, types that are optional will not display " | undefined" in the type.

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -10,7 +10,11 @@ export function buildFilter(opts: ParserOptions): PropFilter {
   return (prop: PropItem, component: Component) => {
     const { propFilter } = opts;
     // skip children property in case it has no custom documentation
-    if (prop.name === 'children' && prop.description.length === 0) {
+    if (
+      prop.name === 'children' &&
+      prop.description.length === 0 &&
+      opts.skipChildrenPropWithoutDoc !== false
+    ) {
       return false;
     }
     if (typeof propFilter === 'function') {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,6 +83,7 @@ export interface ParserOptions {
   shouldExtractLiteralValuesFromEnum?: boolean;
   shouldRemoveUndefinedFromOptional?: boolean;
   shouldExtractValuesFromUnion?: boolean;
+  skipChildrenPropWithoutDoc?: boolean;
   savePropValueAsString?: boolean;
 }
 
@@ -231,9 +232,7 @@ export class Parser {
     this.savePropValueAsString = Boolean(savePropValueAsString);
   }
 
-  private getComponentFromExpression(
-    exp: ts.Symbol,
-  ) {
+  private getComponentFromExpression(exp: ts.Symbol) {
     const declaration = exp.valueDeclaration || exp.declarations![0];
     const type = this.checker.getTypeOfSymbolAtLocation(exp, declaration);
     const typeSymbol = type.symbol || type.aliasSymbol;
@@ -242,11 +241,11 @@ export class Parser {
       return exp;
     }
 
-    const symbolName = typeSymbol.getName()
+    const symbolName = typeSymbol.getName();
 
     if (
-      (symbolName === "MemoExoticComponent" ||
-        symbolName === "ForwardRefExoticComponent") &&
+      (symbolName === 'MemoExoticComponent' ||
+        symbolName === 'ForwardRefExoticComponent') &&
       exp.valueDeclaration &&
       ts.isExportAssignment(exp.valueDeclaration) &&
       ts.isCallExpression(exp.valueDeclaration.expression)
@@ -332,7 +331,9 @@ export class Parser {
     const resolvedComponentName = componentNameResolver(nameSource, source);
     const { description, tags } = this.findDocComment(commentSource);
     const displayName =
-      resolvedComponentName || tags.visibleName || computeComponentName(nameSource, source);
+      resolvedComponentName ||
+      tags.visibleName ||
+      computeComponentName(nameSource, source);
     const methods = this.getMethodsInfo(type);
 
     if (propsType) {


### PR DESCRIPTION
This PR addresses the following issues without introducing a breaking change. If this PR is accepted #285 can be closed. The naming of this option follows the guidance from @pvasek in [this comment](https://github.com/styleguidist/react-docgen-typescript/pull/285#issuecomment-683404412)

closes #284
closes #236