### PR TITLE
Add tags to ComponentDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-typescript",
-  "version": "1.20.1",
+  "version": "1.20.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2204,9 +2204,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
-      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint-staged": "^7.3.0",
     "lodash": "^4.17.15",
     "mocha": "^5.2.0",
-    "prettier": "^1.10.2",
+    "prettier": "^1.19.1",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "source-map-support": "^0.5.6",


### PR DESCRIPTION
It is proposed that the tagMap object be present in ComponentDoc. This can help developers use any tags to customize or filter the components. 