### PR TITLE
Add more information about parent declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ type PropFilter = (prop: PropItem, component: Component) => boolean;
 
 const options = {
   propFilter: (prop: PropItem, component: Component) => {
-    if (prop.parents !== undefined && prop.parents.length > 0) {
-      const hasPropAdditionalDescription = prop.parents.find((parent) => {
-        return !parent.fileName.includes("node_modules");
+    if (prop.declarations !== undefined && prop.declarations.length > 0) {
+      const hasPropAdditionalDescription = prop.declarations.find((declaration) => {
+        return !declaration.fileName.includes("node_modules");
       });
 
       return Boolean(hasPropAdditionalDescription);

--- a/README.md
+++ b/README.md
@@ -109,8 +109,12 @@ type PropFilter = (prop: PropItem, component: Component) => boolean;
 
 const options = {
   propFilter: (prop: PropItem, component: Component) => {
-    if (prop.parent) {
-      return !prop.parent.fileName.includes("node_modules");
+    if (prop.parents !== undefined && prop.parents.length > 0) {
+      const hasPropAdditionalDescription = prop.parents.find((parent) => {
+        return !parent.fileName.includes("node_modules");
+      });
+
+      return Boolean(hasPropAdditionalDescription);
     }
 
     return true;

--- a/src/__tests__/data/ButtonWithOnClickComponent.tsx
+++ b/src/__tests__/data/ButtonWithOnClickComponent.tsx
@@ -1,0 +1,14 @@
+import { FC, PropsWithRef } from 'react';
+
+type HTMLButtonProps = JSX.IntrinsicElements['button'];
+
+type Props = HTMLButtonProps & {
+  /** onClick event handler */
+  onClick?: HTMLButtonProps['onClick'];
+};
+
+const ButtonWithOnClickComponent: FC<Props> = props => {
+  return <button {...props} />;
+};
+
+export default ButtonWithOnClickComponent;

--- a/src/__tests__/data/ColumnWithStaticComponents.tsx
+++ b/src/__tests__/data/ColumnWithStaticComponents.tsx
@@ -6,7 +6,9 @@ interface LabelProps {
 }
 
 /** Column.Label description */
-const SubComponent = (props: LabelProps) => <div>My Property = {props.title}</div>;
+const SubComponent = (props: LabelProps) => (
+  <div>My Property = {props.title}</div>
+);
 
 /**
  * Column properties.
@@ -24,8 +26,8 @@ export class Column extends React.Component<IColumnProps, {}> {
 
   /** Column.SubLabel description */
   public static SubLabel() {
-    return <div>sub</div>
-  };
+    return <div>sub</div>;
+  }
 
   public render() {
     const { prop1 } = this.props;

--- a/src/__tests__/data/ComplexGenericUnionIntersection.tsx
+++ b/src/__tests__/data/ComplexGenericUnionIntersection.tsx
@@ -3,14 +3,15 @@ declare type PropsOf<
 > = JSX.LibraryManagedAttributes<E, React.ComponentPropsWithoutRef<E>>;
 
 /** Props for a Box component that supports the "innerRef" and "as" props. */
-type BoxProps<E extends React.ElementType, P = any> = P & PropsOf<E> & {
-  /** Render the component as another component */
-  as?: E;
-};
+type BoxProps<E extends React.ElementType, P = any> = P &
+  PropsOf<E> & {
+    /** Render the component as another component */
+    as?: E;
+  };
 
 interface StackBaseProps {
   /** The flex "align" property */
-  align?: "stretch" | "center" | "flex-start" | "flex-end";
+  align?: 'stretch' | 'center' | 'flex-start' | 'flex-end';
 }
 
 interface StackJustifyProps {
@@ -18,7 +19,7 @@ interface StackJustifyProps {
    * Use flex 'space-between' | 'space-around' | 'space-evenly' and
    * flex will space the children.
    */
-  justify?: "space-between" | "space-around" | "space-evenly";
+  justify?: 'space-between' | 'space-around' | 'space-evenly';
   /** You cannot use gap when using a "space" justify property */
   gap?: never;
 }
@@ -28,14 +29,14 @@ interface StackGapProps {
    * Use flex 'center' | 'flex-start' | 'flex-end' | 'stretch' with
    * a gap between each child.
    */
-  justify?: "center" | "flex-start" | "flex-end" | "stretch";
+  justify?: 'center' | 'flex-start' | 'flex-end' | 'stretch';
   /** The space between children */
   gap?: number | string;
 }
 
 type StackProps = StackBaseProps & (StackGapProps | StackJustifyProps);
 
-const defaultElement = "div" as const;
+const defaultElement = 'div' as const;
 
 /** ComplexGenericUnionIntersection description */
 export const ComplexGenericUnionIntersection = <

--- a/src/__tests__/data/ForwardRefDefaultExportAtExport.tsx
+++ b/src/__tests__/data/ForwardRefDefaultExportAtExport.tsx
@@ -6,8 +6,9 @@ export interface ForwardRefDefaultExportProps {
 }
 
 /** ForwardRefDefaultExport description */
-const ForwardRefDefaultExport = (props: ForwardRefDefaultExportProps, ref: React.Ref<HTMLDivElement>) => (
-  <div ref={ref}>My Property = {props.myProp}</div>
-)
+const ForwardRefDefaultExport = (
+  props: ForwardRefDefaultExportProps,
+  ref: React.Ref<HTMLDivElement>
+) => <div ref={ref}>My Property = {props.myProp}</div>;
 
 export default React.forwardRef(ForwardRefDefaultExport);

--- a/src/__tests__/data/FunctionDeclarationVisibleName.tsx
+++ b/src/__tests__/data/FunctionDeclarationVisibleName.tsx
@@ -8,7 +8,7 @@ export interface JumbotronProps {
 
 /**
  * Awesome Jumbotron description
- * 
+ *
  * @visibleName Awesome Jumbotron
  */
 export function Jumbotron(props: JumbotronProps) {

--- a/src/__tests__/data/HOCIntersectionProps.tsx
+++ b/src/__tests__/data/HOCIntersectionProps.tsx
@@ -7,8 +7,7 @@ export interface HOCProps {
 }
 
 /** HOCIntersectionProps description */
-export const HOCIntersectionProps: React.SFC<
-  HOCProps & HOCInjectedProps
-> = props => <div />;
+export const HOCIntersectionProps: React.SFC<HOCProps &
+  HOCInjectedProps> = props => <div />;
 
 export default withHOC({})(HOCIntersectionProps);

--- a/src/__tests__/data/StatelessIntersectionExternalProps.tsx
+++ b/src/__tests__/data/StatelessIntersectionExternalProps.tsx
@@ -7,6 +7,5 @@ export interface StatelessProps {
 }
 
 /** StatelessIntersectionExternalProps description */
-export const StatelessIntersectionExternalProps: React.SFC<
-  StatelessProps & ExternalOptionalComponentProps
-> = props => <div />;
+export const StatelessIntersectionExternalProps: React.SFC<StatelessProps &
+  ExternalOptionalComponentProps> = props => <div />;

--- a/src/__tests__/data/StatelessIntersectionProps.tsx
+++ b/src/__tests__/data/StatelessIntersectionProps.tsx
@@ -11,6 +11,5 @@ export interface StatelessMoreProps {
 }
 
 /** StatelessIntersectionProps description */
-export const StatelessIntersectionProps: React.SFC<
-  StatelessProps & StatelessMoreProps
-> = props => <div />;
+export const StatelessIntersectionProps: React.SFC<StatelessProps &
+  StatelessMoreProps> = props => <div />;

--- a/src/__tests__/data/StatelessShorthandDefaultProps.tsx
+++ b/src/__tests__/data/StatelessShorthandDefaultProps.tsx
@@ -10,9 +10,9 @@ export interface StatelessShorthandDefaultPropsProps {
 }
 
 /** StatelessShorthandDefaultProps description */
-export const StatelessShorthandDefaultProps: React.SFC<
-  StatelessShorthandDefaultPropsProps
-> = props => <div />;
+export const StatelessShorthandDefaultProps: React.SFC<StatelessShorthandDefaultPropsProps> = props => (
+  <div />
+);
 
 const shorthandProp = 123;
 

--- a/src/__tests__/data/StatelessStaticComponents.tsx
+++ b/src/__tests__/data/StatelessStaticComponents.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 
 interface LabelProps {
   /** title description */
@@ -6,7 +6,9 @@ interface LabelProps {
 }
 
 /** StatelessStaticComponents.Label description */
-const SubComponent = (props: LabelProps) => <div>My Property = {props.title}</div>;
+const SubComponent = (props: LabelProps) => (
+  <div>My Property = {props.title}</div>
+);
 
 interface StatelessStaticComponentsProps {
   /** myProp description */
@@ -14,8 +16,8 @@ interface StatelessStaticComponentsProps {
 }
 
 /** StatelessStaticComponents description */
-export const StatelessStaticComponents = (props: StatelessStaticComponentsProps) => (
-  <div>My Property = {props.myProp}</div>
-);
+export const StatelessStaticComponents = (
+  props: StatelessStaticComponentsProps
+) => <div>My Property = {props.myProp}</div>;
 
 StatelessStaticComponents.Label = SubComponent;

--- a/src/__tests__/data/StatelessWithDefaultOnlyJsDoc.tsx
+++ b/src/__tests__/data/StatelessWithDefaultOnlyJsDoc.tsx
@@ -5,6 +5,6 @@ export interface StatelessWithDefaultOnlyJsDocProps {
   myProp: string;
 }
 /** StatelessWithDefaultOnlyJsDoc description */
-export const StatelessWithDefaultOnlyJsDoc: React.StatelessComponent<
-  StatelessWithDefaultOnlyJsDocProps
-> = props => <div>My Property = {props.myProp}</div>;
+export const StatelessWithDefaultOnlyJsDoc: React.StatelessComponent<StatelessWithDefaultOnlyJsDocProps> = props => (
+  <div>My Property = {props.myProp}</div>
+);

--- a/src/__tests__/data/StatelessWithDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithDefaultProps.tsx
@@ -31,9 +31,9 @@ export interface StatelessWithDefaultPropsProps {
 }
 
 /** StatelessWithDefaultProps description */
-export const StatelessWithDefaultProps: React.StatelessComponent<
-  StatelessWithDefaultPropsProps
-> = props => <div>test</div>;
+export const StatelessWithDefaultProps: React.StatelessComponent<StatelessWithDefaultPropsProps> = props => (
+  <div>test</div>
+);
 
 StatelessWithDefaultProps.defaultProps = {
   sampleEnum: enumSample.HELLO,

--- a/src/__tests__/data/StatelessWithDefaultPropsAsString.tsx
+++ b/src/__tests__/data/StatelessWithDefaultPropsAsString.tsx
@@ -16,9 +16,9 @@ export interface StatelessWithDefaultPropsAsStringProps {
   sampleUndefined?: undefined;
 }
 
-export const StatelessWithDefaultPropsAsString: React.StatelessComponent<
-  StatelessWithDefaultPropsAsStringProps
-> = props => <div>test</div>;
+export const StatelessWithDefaultPropsAsString: React.StatelessComponent<StatelessWithDefaultPropsAsStringProps> = props => (
+  <div>test</div>
+);
 
 StatelessWithDefaultPropsAsString.defaultProps = {
   sampleFalse: false,

--- a/src/__tests__/data/StatelessWithDefaultPropsTypescript3.tsx
+++ b/src/__tests__/data/StatelessWithDefaultPropsTypescript3.tsx
@@ -31,9 +31,9 @@ export interface StatelessWithDefaultPropsProps {
 }
 
 /** StatelessWithDefaultProps description */
-export const StatelessWithDefaultProps: React.StatelessComponent<
-  StatelessWithDefaultPropsProps
-> = props => <div>test</div>;
+export const StatelessWithDefaultProps: React.StatelessComponent<StatelessWithDefaultPropsProps> = props => (
+  <div>test</div>
+);
 
 StatelessWithDefaultProps.defaultProps = {
   sampleEnum: enumSample.HELLO,

--- a/src/__tests__/data/StatelessWithDestructuredPropsArrow.tsx
+++ b/src/__tests__/data/StatelessWithDestructuredPropsArrow.tsx
@@ -31,9 +31,7 @@ export interface StatelessWithDefaultPropsProps {
 }
 
 /** StatelessWithDefaultProps description */
-export const StatelessWithDefaultProps: React.StatelessComponent<
-  StatelessWithDefaultPropsProps
-> = ({
+export const StatelessWithDefaultProps: React.StatelessComponent<StatelessWithDefaultPropsProps> = ({
   sampleEnum = enumSample.HELLO,
   sampleFalse = false,
   sampleNull = null,

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -741,11 +741,11 @@ describe('parser', () => {
     });
   });
 
-  it("should parse functional component component defined as function as default export", () => {
-    check("FunctionDeclarationAsDefaultExport", {
+  it('should parse functional component component defined as function as default export', () => {
+    check('FunctionDeclarationAsDefaultExport', {
       Jumbotron: {
-        prop1: { type: "string", required: true },
-      },
+        prop1: { type: 'string', required: true }
+      }
     });
   });
 

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -984,12 +984,41 @@ describe('parser', () => {
         });
       });
 
-      it('should allow filtering by parent interfaces', () => {
+      it('should collect all `onClick prop` parent declarations', done => {
+        assert.doesNotThrow(() => {
+          withDefaultConfig({
+            propFilter: prop => {
+              if (prop.name === 'onClick') {
+                assert.deepEqual(prop.declarations, [
+                  {
+                    fileName:
+                      'react-docgen-typescript/node_modules/@types/react/index.d.ts',
+                    name: 'DOMAttributes'
+                  },
+                  {
+                    fileName:
+                      'react-docgen-typescript/src/__tests__/data/ButtonWithOnClickComponent.tsx',
+                    name: 'TypeLiteral'
+                  }
+                ]);
+
+                done();
+              }
+
+              return true;
+            }
+          }).parse(fixturePath('ButtonWithOnClickComponent'));
+        });
+      });
+
+      it('should allow filtering by parent declarations', () => {
         const propFilter: PropFilter = prop => {
-          if (prop.parents !== undefined && prop.parents.length > 0) {
-            const hasPropAdditionalDescription = prop.parents.find(parent => {
-              return !parent.fileName.includes('@types/react');
-            });
+          if (prop.declarations !== undefined && prop.declarations.length > 0) {
+            const hasPropAdditionalDescription = prop.declarations.find(
+              declaration => {
+                return !declaration.fileName.includes('@types/react');
+              }
+            );
 
             return Boolean(hasPropAdditionalDescription);
           }

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -12,8 +12,6 @@ import {
 import { check, checkComponent, fixturePath } from './testUtils';
 
 describe('parser', () => {
-  const children = { type: 'ReactNode', required: false, description: '' };
-
   it('should parse simple react class component', () => {
     check('Column', {
       Column: {
@@ -984,6 +982,39 @@ describe('parser', () => {
             { propFilter }
           );
         });
+      });
+
+      it('should allow filtering by parent interfaces', () => {
+        const propFilter: PropFilter = prop => {
+          if (prop.parents !== undefined && prop.parents.length > 0) {
+            const hasPropAdditionalDescription = prop.parents.find(parent => {
+              return !parent.fileName.includes('@types/react');
+            });
+
+            return Boolean(hasPropAdditionalDescription);
+          }
+
+          return true;
+        };
+
+        check(
+          'ButtonWithOnClickComponent',
+          {
+            ButtonWithOnClickComponent: {
+              onClick: {
+                type:
+                  '(event: MouseEvent<HTMLButtonElement, MouseEvent>) => void',
+                required: false,
+                description: 'onClick event handler'
+              }
+            }
+          },
+          true,
+          '',
+          {
+            propFilter
+          }
+        );
       });
 
       describe('skipPropsWithName', () => {

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -91,9 +91,7 @@ export function checkComponent(
     if (componentDoc.description !== expectedComponentDescription) {
       // tslint:disable-next-line:max-line-length
       errors.push(
-        `${compName} description is different - expected: '${expectedComponentDescription}', actual: '${
-          componentDoc.description
-        }'`
+        `${compName} description is different - expected: '${expectedComponentDescription}', actual: '${componentDoc.description}'`
       );
     }
 
@@ -120,9 +118,7 @@ export function checkComponent(
         if (expectedProp.type !== prop.type.name) {
           // tslint:disable-next-line:max-line-length
           errors.push(
-            `Property '${compName}.${expectedPropName}' type is different - expected: ${
-              expectedProp.type
-            }, actual: ${prop.type.name}`
+            `Property '${compName}.${expectedPropName}' type is different - expected: ${expectedProp.type}, actual: ${prop.type.name}`
           );
         }
         const expectedDescription =
@@ -132,9 +128,7 @@ export function checkComponent(
         if (expectedDescription !== prop.description) {
           errors.push(
             // tslint:disable-next-line:max-line-length
-            `Property '${compName}.${expectedPropName}' description is different - expected: ${expectedDescription}, actual: ${
-              prop.description
-            }`
+            `Property '${compName}.${expectedPropName}' description is different - expected: ${expectedDescription}, actual: ${prop.description}`
           );
         }
         const expectedParentFileName = expectedProp.parent
@@ -147,9 +141,7 @@ export function checkComponent(
         ) {
           errors.push(
             // tslint:disable-next-line:max-line-length
-            `Property '${compName}.${expectedPropName}' parent fileName is different - expected: ${expectedParentFileName}, actual: ${
-              prop.parent.fileName
-            }`
+            `Property '${compName}.${expectedPropName}' parent fileName is different - expected: ${expectedParentFileName}, actual: ${prop.parent.fileName}`
           );
         }
         const expectedRequired =
@@ -157,9 +149,7 @@ export function checkComponent(
         if (expectedRequired !== prop.required) {
           errors.push(
             // tslint:disable-next-line:max-line-length
-            `Property '${compName}.${expectedPropName}' required is different - expected: ${expectedRequired}, actual: ${
-              prop.required
-            }`
+            `Property '${compName}.${expectedPropName}' required is different - expected: ${expectedRequired}, actual: ${prop.required}`
           );
         }
         const expectedDefaultValue = expectedProp.defaultValue;
@@ -179,9 +169,7 @@ export function checkComponent(
         if (exptectedRaw && exptectedRaw !== prop.type.raw) {
           // tslint:disable-next-line:max-line-length
           errors.push(
-            `Property '${compName}.${expectedPropName}' raw value is different - expected: ${exptectedRaw}, actual: ${
-              prop.type.raw
-            }`
+            `Property '${compName}.${expectedPropName}' raw value is different - expected: ${exptectedRaw}, actual: ${prop.type.raw}`
           );
         }
         const expectedValue = expectedProp.value;


### PR DESCRIPTION
### Summary

As a developer I would like to have extended information about property type declaration. As some of props could be described as an inheritance of types in `node_modules` it's impossible to opt in such props in `propFilter` function and opt out all the props from `node_modules`.

### Example

```tsx
import { FC, PropsWithRef } from 'react';

type HTMLButtonProps = JSX.IntrinsicElements['button'];

type Props = HTMLButtonProps & {
  /** onClick event handler */
  onClick?: HTMLButtonProps['onClick'];
};

const ButtonWithOnClickComponent: FC<Props> = props => {
  return <button {...props} />;
};

export default ButtonWithOnClickComponent;
```

Current version of `react-docgen-typescript` will generate next prop description

```js
{
   onClick: {
     // ... 
    parent: {
        fileName: "node_modules/@types/react/index.d.ts",
        // ...
    }
  }
}

```

### Proposal

Provide an ability to retrieve all the parent declarations of prop. I have specified an additional `parents` field to the prop declaration that exposes all the Node declarations that typescript handles.

