### PR TITLE
find const name if we can

### DIFF
--- a/src/__tests__/data/switch.tsx
+++ b/src/__tests__/data/switch.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export interface SwitchProps {
+  /** isActive description */
+  isActive: boolean;
+}
+
+/** Switch description */
+const Switch: React.FunctionComponent<SwitchProps> = props => {
+  return <div>hello world</div>;
+};
+
+export default Switch;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -182,6 +182,18 @@ describe('parser', () => {
     );
   });
 
+  it('should find name for default export', () => {
+    check(
+      'switch',
+      {
+        Switch: {
+          isActive: { type: 'boolean' }
+        }
+      },
+      false
+    );
+  });
+
   it('should parse react component with properties defined in external file', () => {
     check('ExternalPropsComponent', {
       ExternalPropsComponent: {
@@ -741,11 +753,11 @@ describe('parser', () => {
     });
   });
 
-  it("should parse functional component component defined as function as default export", () => {
-    check("FunctionDeclarationAsDefaultExport", {
+  it('should parse functional component component defined as function as default export', () => {
+    check('FunctionDeclarationAsDefaultExport', {
       Jumbotron: {
-        prop1: { type: "string", required: true },
-      },
+        prop1: { type: 'string', required: true }
+      }
     });
   });
 
@@ -770,34 +782,6 @@ describe('parser', () => {
     );
   });
 
-  it('should parse functional component component defined as const as default export', () => {
-    check(
-      'FunctionalComponentAsConstAsDefaultExport',
-      {
-        // in this case the component name is taken from the file name
-        FunctionalComponentAsConstAsDefaultExport: {
-          prop1: { type: 'string', required: true }
-        }
-      },
-      true,
-      'Jumbotron description'
-    );
-  });
-
-  it('should parse React.SFC component defined as const as default export', () => {
-    check(
-      'ReactSFCAsConstAsDefaultExport',
-      {
-        // in this case the component name is taken from the file name
-        ReactSFCAsConstAsDefaultExport: {
-          prop1: { type: 'string', required: true }
-        }
-      },
-      true,
-      'Jumbotron description'
-    );
-  });
-
   it('should parse functional component component defined as const as named export', () => {
     check(
       'FunctionalComponentAsConstAsNamedExport',
@@ -816,7 +800,6 @@ describe('parser', () => {
     check(
       'ReactSFCAsConstAsNamedExport',
       {
-        // in this case the component name is taken from the file name
         Jumbotron: {
           prop1: { type: 'string', required: true }
         }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -326,13 +326,13 @@ export class Parser {
       this.extractPropsFromTypeIfStatelessComponent(type) ||
       this.extractPropsFromTypeIfStatefulComponent(type);
 
-    const nameSource = originalName === 'default' ? rootExp : commentSource;
-    const resolvedComponentName = componentNameResolver(nameSource, source);
+    const resolvedComponentName = componentNameResolver(commentSource, source);
     const { description, tags } = this.findDocComment(commentSource);
+
     const displayName =
       resolvedComponentName ||
       tags.visibleName ||
-      computeComponentName(nameSource, source);
+      computeComponentName(commentSource, source);
     const methods = this.getMethodsInfo(type);
 
     if (propsType) {


### PR DESCRIPTION
If we use the name of the file and that name is a reserved JS keyword things fail. How most libraries attach the docgen information is by adding code like the following to the component file:

**`switch.tsx`**

```tsx
import React, { FunctionComponent } from \\"react\\";

export interface SwitchProps {
  isActive: boolean;
  onSelect: () => void;
}

const Switch: FunctionComponent<SwitchProps> = (props) => {
  return <div>hello world</div>;
};

export default Switch;

try {
    // @ts-ignore
    switch.displayName = \\"switch\\";
    // @ts-ignore
    switch.__docgenInfo = { \\"description\\": \\"\\", \\"displayName\\": \\"switch\\", \\"props\\": { \\"isActive\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"isActive\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"boolean\\" } }, \\"onSelect\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"onSelect\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"() => void\\" } } } };
}
catch (__react_docgen_typescript_loader_error) { }
```

You can see that since the filename is a reserved keyword the docs are attached at the wrong place. In this case we can actually find the real name of the component so we should just use that since it's possible.

This is a breaking change but I think it provides a better behavior

**`someComponentFile.tsx`**

```tsx
import React, { FunctionComponent } from \\"react\\";

export interface SwitchProps {
  isActive: boolean;
  onSelect: () => void;
}

const Switch: FunctionComponent<SwitchProps> = (props) => {
  return <div>hello world</div>;
};

export default Switch;

try {
    // @ts-ignore
    someComponentFile.displayName = \\"someComponentFile\\";
    // @ts-ignore
    someComponentFile.__docgenInfo = { \\"description\\": \\"\\", \\"displayName\\": \\"switch\\", \\"props\\": { \\"isActive\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"isActive\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"boolean\\" } }, \\"onSelect\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"onSelect\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"() => void\\" } } } };
}
catch (__react_docgen_typescript_loader_error) { }
```

Using the real display name seems better but i'm open to suggestions.

https://github.com/storybookjs/storybook/issues/13301