### PR TITLE
improve shouldExtractLiteralValuesFromEnum

### DIFF
--- a/src/__tests__/data/GenericWithExtends.tsx
+++ b/src/__tests__/data/GenericWithExtends.tsx
@@ -1,6 +1,11 @@
 //In our case we have a component that works like the foolowing
 
 type SampleUnion = 'value 1' | 'value 2' | 'value 3' | 'value 4' | 'value n';
+enum SampleEnum {
+  A,
+  B,
+  C = 'c'
+}
 type SampleObject = {
   propA: string;
   propB: object;
@@ -15,11 +20,14 @@ class SampleUnionNonGeneric extends Base {
 
 export const GenericWithExtends = <
   G extends SampleUnion,
+  E extends SampleEnum,
   A extends number[],
   O extends { prop1: number }
 >(props: {
   /** sampleUnionProp description */
   sampleUnionProp: G;
+  /** sampleEnumProp description */
+  sampleEnumProp: E;
   /** sampleUnionNonGeneric description */
   sampleUnionNonGeneric: SampleUnionNonGeneric;
   /** sampleObjectProp description */

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1191,6 +1191,21 @@ describe('parser', () => {
                   }
                 ]
               },
+              sampleEnumProp: {
+                raw: 'SampleEnum',
+                type: 'enum',
+                value: [
+                  {
+                    value: '0'
+                  },
+                  {
+                    value: '1'
+                  },
+                  {
+                    value: '"c"'
+                  }
+                ]
+              },
               sampleUnionNonGeneric: {
                 type: 'SampleUnionNonGeneric'
               },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -560,26 +560,20 @@ export class Parser {
     let propTypeString = this.checker.typeToString(propType);
 
     if (propType.isUnion()) {
-      if (this.shouldExtractValuesFromUnion) {
-        return {
-          name: 'enum',
-          raw: propTypeString,
-          value: propType.types.map(type => ({
-            value: this.getValuesFromUnionType(type)
-          }))
-        };
-      }
       if (
-        this.shouldExtractLiteralValuesFromEnum &&
-        propType.types.every(type => type.isStringLiteral())
+        this.shouldExtractValuesFromUnion ||
+        (this.shouldExtractLiteralValuesFromEnum &&
+          propType.types.every(
+            type =>
+              type.getFlags() &
+              (ts.TypeFlags.EnumLiteral | ts.TypeFlags.Undefined)
+          ))
       ) {
         return {
           name: 'enum',
           raw: propTypeString,
           value: propType.types.map(type => ({
-            value: type.isStringLiteral()
-              ? `"${type.value}"`
-              : this.checker.typeToString(type)
+            value: this.getValuesFromUnionType(type)
           }))
         };
       }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -566,7 +566,10 @@ export class Parser {
           propType.types.every(
             type =>
               type.getFlags() &
-              (ts.TypeFlags.EnumLiteral | ts.TypeFlags.Undefined)
+              (ts.TypeFlags.StringLiteral |
+                ts.TypeFlags.NumberLiteral |
+                ts.TypeFlags.EnumLiteral |
+                ts.TypeFlags.Undefined)
           ))
       ) {
         return {


### PR DESCRIPTION
### More accurate determination of enumeration type and return the expected enumeration value

fixed: the following example does not generate an enumerated type
``` ts
export enum Mode {
  A,
  B,
}

export enum Mode {
  A,
  B = "b",
}
```

fixed: return the expected enumeration value
 ```ts
export enum Mode {
  A,
  B = "b",
}

// old generated 
 "type": {
    "name": "enum",
    "raw": "Mode",
    "value": [
      {
        "value": "Mode.A"
      },
      {
        "value": "\"b\""
      }
    ]
  }

// new generated 
"type": {
    "name": "enum",
    "raw": "Mode",
    "value": [
      {
        "value": "0"
      },
      {
        "value": "\"b\""
      }
    ]
  }

```


