### PR TITLE
Add default export support to compound/static components

### DIFF
--- a/src/__tests__/data/StatelessStaticComponentsDefaultExport.tsx
+++ b/src/__tests__/data/StatelessStaticComponentsDefaultExport.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+interface LabelProps {
+  /** title description */
+  title: string;
+}
+
+/** StatelessStaticComponentsDefaultExport.Label description */
+const SubComponent = (props: LabelProps) => (
+  <div>My Property = {props.title}</div>
+);
+
+interface StatelessStaticComponentsDefaultExportProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** StatelessStaticComponentsDefaultExport description */
+const StatelessStaticComponentsDefaultExport = (
+  props: StatelessStaticComponentsDefaultExportProps
+) => {
+  return <div>My Property = {props.myProp}</div>;
+};
+
+StatelessStaticComponentsDefaultExport.Label = SubComponent;
+
+export default StatelessStaticComponentsDefaultExport;

--- a/src/__tests__/data/StatelessStaticComponentsDefaultFunctionExport.tsx
+++ b/src/__tests__/data/StatelessStaticComponentsDefaultFunctionExport.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+interface LabelProps {
+  /** title description */
+  title: string;
+}
+
+/** StatelessStaticComponentsDefaultFunctionExport.Label description */
+const SubComponent = (props: LabelProps) => (
+  <div>My Property = {props.title}</div>
+);
+
+interface StatelessStaticComponentsDefaultFunctionExportProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** StatelessStaticComponentsDefaultFunctionExport description */
+export default function StatelessStaticComponentsDefaultFunctionExport(
+  props: StatelessStaticComponentsDefaultFunctionExportProps
+) {
+  return <div>My Property = {props.myProp}</div>;
+}
+
+StatelessStaticComponentsDefaultFunctionExport.Label = SubComponent;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -213,6 +213,28 @@ describe('parser', () => {
     });
   });
 
+  it('should parse static sub components on default function exports', () => {
+    check('StatelessStaticComponentsDefaultFunctionExport', {
+      StatelessStaticComponentsDefaultFunctionExport: {
+        myProp: { type: 'string' }
+      },
+      'StatelessStaticComponentsDefaultFunctionExport.Label': {
+        title: { type: 'string' }
+      }
+    });
+  });
+
+  it.only('should parse static sub components on default exports', () => {
+    check('StatelessStaticComponentsDefaultExport', {
+      StatelessStaticComponentsDefaultExport: {
+        myProp: { type: 'string' }
+      },
+      'StatelessStaticComponentsDefaultExport.Label': {
+        title: { type: 'string' }
+      }
+    });
+  });
+
   it('should parse react component with properties extended from an external .tsx file', () => {
     check('ExtendsExternalPropsComponent', {
       ExtendsExternalPropsComponent: {
@@ -741,11 +763,11 @@ describe('parser', () => {
     });
   });
 
-  it("should parse functional component component defined as function as default export", () => {
-    check("FunctionDeclarationAsDefaultExport", {
+  it('should parse functional component component defined as function as default export', () => {
+    check('FunctionDeclarationAsDefaultExport', {
       Jumbotron: {
-        prop1: { type: "string", required: true },
-      },
+        prop1: { type: 'string', required: true }
+      }
     });
   });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -141,9 +141,7 @@ export function withCustomConfig(
 
   if (error !== undefined) {
     // tslint:disable-next-line: max-line-length
-    const errorText = `Cannot load custom tsconfig.json from provided path: ${tsconfigPath}, with error code: ${
-      error.code
-    }, message: ${error.messageText}`;
+    const errorText = `Cannot load custom tsconfig.json from provided path: ${tsconfigPath}, with error code: ${error.code}, message: ${error.messageText}`;
     throw new Error(errorText);
   }
 
@@ -231,9 +229,7 @@ export class Parser {
     this.savePropValueAsString = Boolean(savePropValueAsString);
   }
 
-  private getComponentFromExpression(
-    exp: ts.Symbol,
-  ) {
+  private getComponentFromExpression(exp: ts.Symbol) {
     const declaration = exp.valueDeclaration || exp.declarations![0];
     const type = this.checker.getTypeOfSymbolAtLocation(exp, declaration);
     const typeSymbol = type.symbol || type.aliasSymbol;
@@ -242,11 +238,11 @@ export class Parser {
       return exp;
     }
 
-    const symbolName = typeSymbol.getName()
+    const symbolName = typeSymbol.getName();
 
     if (
-      (symbolName === "MemoExoticComponent" ||
-        symbolName === "ForwardRefExoticComponent") &&
+      (symbolName === 'MemoExoticComponent' ||
+        symbolName === 'ForwardRefExoticComponent') &&
       exp.valueDeclaration &&
       ts.isExportAssignment(exp.valueDeclaration) &&
       ts.isCallExpression(exp.valueDeclaration.expression)
@@ -332,7 +328,9 @@ export class Parser {
     const resolvedComponentName = componentNameResolver(nameSource, source);
     const { description, tags } = this.findDocComment(commentSource);
     const displayName =
-      resolvedComponentName || tags.visibleName || computeComponentName(nameSource, source);
+      resolvedComponentName ||
+      tags.visibleName ||
+      computeComponentName(nameSource, source);
     const methods = this.getMethodsInfo(type);
 
     if (propsType) {
@@ -814,9 +812,9 @@ export class Parser {
         let propMap = {};
 
         if (properties) {
-          propMap = this.getPropMap(properties as ts.NodeArray<
-            ts.PropertyAssignment
-          >);
+          propMap = this.getPropMap(
+            properties as ts.NodeArray<ts.PropertyAssignment>
+          );
         }
 
         return {
@@ -846,9 +844,9 @@ export class Parser {
           if (right) {
             const { properties } = right as ts.ObjectLiteralExpression;
             if (properties) {
-              propMap = this.getPropMap(properties as ts.NodeArray<
-                ts.PropertyAssignment
-              >);
+              propMap = this.getPropMap(
+                properties as ts.NodeArray<ts.PropertyAssignment>
+              );
             }
           }
         });
@@ -951,31 +949,26 @@ export class Parser {
   public getPropMap(
     properties: ts.NodeArray<ts.PropertyAssignment | ts.BindingElement>
   ): StringIndexedObject<string | boolean | number | null> {
-    const propMap = properties.reduce(
-      (acc, property) => {
-        if (ts.isSpreadAssignment(property) || !property.name) {
-          return acc;
-        }
-
-        const literalValue = this.getLiteralValueFromPropertyAssignment(
-          property
-        );
-        const propertyName = getPropertyName(property.name);
-
-        if (
-          (typeof literalValue === 'string' ||
-            typeof literalValue === 'number' ||
-            typeof literalValue === 'boolean' ||
-            literalValue === null) &&
-          propertyName !== null
-        ) {
-          acc[propertyName] = literalValue;
-        }
-
+    const propMap = properties.reduce((acc, property) => {
+      if (ts.isSpreadAssignment(property) || !property.name) {
         return acc;
-      },
-      {} as StringIndexedObject<string | boolean | number | null>
-    );
+      }
+
+      const literalValue = this.getLiteralValueFromPropertyAssignment(property);
+      const propertyName = getPropertyName(property.name);
+
+      if (
+        (typeof literalValue === 'string' ||
+          typeof literalValue === 'number' ||
+          typeof literalValue === 'boolean' ||
+          literalValue === null) &&
+        propertyName !== null
+      ) {
+        acc[propertyName] = literalValue;
+      }
+
+      return acc;
+    }, {} as StringIndexedObject<string | boolean | number | null>);
 
     return propMap;
   }
@@ -1228,9 +1221,11 @@ function parseWithProgramProvider(
           parserOpts.componentNameResolver
         );
 
-        if (doc) {
-          componentDocs.push(doc);
+        if (!doc) {
+          return;
         }
+
+        componentDocs.push(doc);
 
         if (!exp.exports) {
           return;
@@ -1251,16 +1246,16 @@ function parseWithProgramProvider(
             }
           }
 
-          const doc = parser.getComponentInfo(
+          const subDoc = parser.getComponentInfo(
             symbol,
             sourceFile,
             parserOpts.componentNameResolver
           );
 
-          if (doc) {
+          if (subDoc) {
             componentDocs.push({
-              ...doc,
-              displayName: `${exp.escapedName}.${symbol.escapedName}`
+              ...subDoc,
+              displayName: `${doc.displayName}.${symbol.escapedName}`
             });
           }
         });


### PR DESCRIPTION
@hipstersmoothie I figured out the case for `export function Blah` but declaring the function, then exporting the reference seems to behave differently. It does not populate the `exp.exports` property. I am not particularly familiar with TS internals, do you know of any good resources that you used while figuring this out?

fixes: #324