### PR TITLE
Added tags for props to serialization (including ParserOption to enable)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-typescript",
-  "version": "1.20.5",
+  "version": "1.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/data/ExtractPropTags.tsx
+++ b/src/__tests__/data/ExtractPropTags.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+interface Todo {
+  title: string;
+  description: string;
+  completed: boolean;
+}
+
+/** ExtractPropTags props */
+export interface ExtractPropTagsProps {
+  /**
+   * prop1 description
+   * @ignore ignoreMe
+   * @kind category 2
+   * @custom123 something
+   */
+  prop1?: Pick<Todo, 'title' | 'completed'>;
+  /** prop2 description
+   * @internal some internal prop
+   * @kind category 1
+   */
+  prop2: string;
+}
+
+const ExtractPropTags = (props: ExtractPropTagsProps) => {
+  return <div>Test</div>;
+};
+
+export { ExtractPropTags };

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1333,6 +1333,33 @@ describe('parser', () => {
         );
       });
     });
+    describe("Extract prop's JSDoc/TSDoc tags", () => {
+      it('should extract all prop JSDoc/TSDoc tags', () => {
+        check(
+          'ExtractPropTags',
+          {
+            ExtractPropTags: {
+              prop1: {
+                type: 'Pick<Todo, "title" | "completed">',
+                required: false,
+                tags: {
+                  ignore: 'ignoreMe',
+                  kind: 'category 2',
+                  custom123: 'something'
+                }
+              },
+              prop2: {
+                type: 'string',
+                tags: { internal: 'some internal prop', kind: 'category 1' }
+              }
+            }
+          },
+          true,
+          null,
+          { shouldIncludePropTagMap: true }
+        );
+      });
+    });
   });
 
   describe('withCustomConfig', () => {
@@ -1525,31 +1552,5 @@ describe('parser', () => {
         ''
       );
     });
-  });
-
-  it.only("should parse prop's JSDoc/TSDoc tags", () => {
-    check(
-      'ExtractPropTags',
-      {
-        ExtractPropTags: {
-          prop1: {
-            type: 'Pick<Todo, "title" | "completed">',
-            required: false,
-            tags: {
-              ignore: 'ignoreMe',
-              kind: 'category 2',
-              custom123: 'something'
-            }
-          },
-          prop2: {
-            type: 'string',
-            tags: { internal: 'some internal prop', kind: 'category 1' }
-          }
-        }
-      },
-      true,
-      null,
-      { shouldIncludePropTagMap: true }
-    );
   });
 });

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1526,4 +1526,30 @@ describe('parser', () => {
       );
     });
   });
+
+  it.only("should parse prop's JSDoc/TSDoc tags", () => {
+    check(
+      'ExtractPropTags',
+      {
+        ExtractPropTags: {
+          prop1: {
+            type: 'Pick<Todo, "title" | "completed">',
+            required: false,
+            tags: {
+              ignore: 'ignoreMe',
+              kind: 'category 2',
+              custom123: 'something'
+            }
+          },
+          prop2: {
+            type: 'string',
+            tags: { internal: 'some internal prop', kind: 'category 1' }
+          }
+        }
+      },
+      true,
+      null,
+      { shouldIncludePropTagMap: true }
+    );
+  });
 });

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -27,6 +27,9 @@ export interface ExpectedProp {
   };
   raw?: string;
   value?: any;
+  tags?: {
+    [key: string]: string;
+  };
 }
 
 export function fixturePath(componentName: string) {
@@ -179,6 +182,15 @@ export function checkComponent(
             `Property '${compName}.${expectedPropName}' value is different - expected: ${JSON.stringify(
               expectedValue
             )}, actual: ${JSON.stringify(prop.type.value)}`
+          );
+        }
+        const expectedPropTags = expectedProp.tags;
+        const propTags = prop.tags;
+        if (expectedPropTags && !isEqual(expectedPropTags, propTags)) {
+          errors.push(
+            `Property '${compName}.${expectedPropName}' tags are different - expected: ${JSON.stringify(
+              expectedPropTags
+            )}, actual: ${JSON.stringify(propTags)}`
           );
         }
       }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,6 +35,7 @@ export interface PropItem {
   defaultValue: any;
   parent?: ParentType;
   declarations?: ParentType[];
+  tags?: {};
 }
 
 export interface Method {
@@ -89,6 +90,7 @@ export interface ParserOptions {
   shouldExtractValuesFromUnion?: boolean;
   skipChildrenPropWithoutDoc?: boolean;
   savePropValueAsString?: boolean;
+  shouldIncludePropTagMap?: boolean;
 }
 
 export interface StaticPropFilter {
@@ -214,13 +216,15 @@ export class Parser {
   private shouldExtractLiteralValuesFromEnum: boolean;
   private shouldExtractValuesFromUnion: boolean;
   private savePropValueAsString: boolean;
+  private shouldIncludePropTagMap: boolean;
 
   constructor(program: ts.Program, opts: ParserOptions) {
     const {
       savePropValueAsString,
       shouldExtractLiteralValuesFromEnum,
       shouldRemoveUndefinedFromOptional,
-      shouldExtractValuesFromUnion
+      shouldExtractValuesFromUnion,
+      shouldIncludePropTagMap
     } = opts;
     this.checker = program.getTypeChecker();
     this.propFilter = buildFilter(opts);
@@ -232,6 +236,7 @@ export class Parser {
     );
     this.shouldExtractValuesFromUnion = Boolean(shouldExtractValuesFromUnion);
     this.savePropValueAsString = Boolean(savePropValueAsString);
+    this.shouldIncludePropTagMap = Boolean(shouldIncludePropTagMap);
   }
 
   private getComponentFromExpression(exp: ts.Symbol) {
@@ -670,14 +675,22 @@ export class Parser {
           }
         : this.getDocgenType(propType, required);
 
+      const propTags = this.shouldIncludePropTagMap
+        ? { tags: jsDocComment.tags }
+        : {};
+      const description = this.shouldIncludePropTagMap
+        ? jsDocComment.description.replace(/\r\n/g, '\n')
+        : jsDocComment.fullComment.replace(/\r\n/g, '\n');
+
       result[propName] = {
         defaultValue,
-        description: jsDocComment.fullComment,
+        description: description,
         name: propName,
         parent,
         declarations: parents,
         required,
-        type
+        type,
+        ...propTags
       };
     });
 
@@ -719,7 +732,7 @@ export class Parser {
     );
 
     if (mainComment) {
-      mainComment = mainComment.replace('\r\n', '\n');
+      mainComment = mainComment.replace(/\r\n/g, '\n');
     }
 
     const tags = symbol.getJsDocTags() || [];

--- a/zTest.js
+++ b/zTest.js
@@ -1,9 +1,0 @@
-const path = require('path');
-const docgen = require("./lib/parser");
-
-function fixturePath(componentName) {
-  return path.join(__dirname, "src", "__tests__", "data", `${componentName}.tsx`); // it's running in ./temp
-}
-
-const res = docgen.parse(fixturePath("FunctionalComponentsWithPropTags"), { shouldIncludePropTagMap: true, shouldExtractValuesFromUnion: true, shouldExtractLiteralValuesFromEnum: true });
-console.log(res);

--- a/zTest.js
+++ b/zTest.js
@@ -1,0 +1,9 @@
+const path = require('path');
+const docgen = require("./lib/parser");
+
+function fixturePath(componentName) {
+  return path.join(__dirname, "src", "__tests__", "data", `${componentName}.tsx`); // it's running in ./temp
+}
+
+const res = docgen.parse(fixturePath("FunctionalComponentsWithPropTags"), { shouldIncludePropTagMap: true, shouldExtractValuesFromUnion: true, shouldExtractLiteralValuesFromEnum: true });
+console.log(res);


### PR DESCRIPTION
@pvasek  sorry for the delay. 
I've updated the PR to 1.21.0, added the union test for the PR and added test functionality to check prop tags in testUtils.ts.
I've also made an additional change in src/parser.ts: 

Only if the added ParserOption shouldIncludePropTagMap is true, instead of jsDocComment.fullComment (default), jsDocComment.description is used as prop description. This will return the plain property description without any tags while tags are served separately. **Default behavior (shouldIncludePropTagMap is false or undefined) is unchanged**. 

I think that would also be an option for default behavior (if so the additional ParserOption would be obsolete). Currently property tags are included in the description as string: 
`
  /** prop2 description
   * @internal some internal prop
   * @kind category 1
   */
  prop2: string;

**==> output default/currently:** 
result[0].props.prop2.description => "prop2 description\n@internal some internal prop\n@kind category 1" 

**==> output (shouldIncludePropTagMap===true ):** 
result[0].props.prop2.description => "prop2 description"
result[0].props.prop2.tags => {internal: "some internal prop", .... }
`

I hope the PR is acceptable now, otherwise please let me know. 
