### PR TITLE
Support boolean literals in extracted union/enum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,29 @@ If a string is returned, then the component will use that name. Else it will fal
 
 ### `shouldExtractLiteralValuesFromEnum`: boolean
 
-If set to true, string enums and unions will be converted to docgen enum format. Useful if you use Storybook and want to generate knobs automatically using [addon-smart-knobs](https://github.com/storybookjs/addon-smart-knobs).
+If set to true, enums and unions of literal values will be converted to docgen enum format. Useful if you use Storybook and want to generate knobs automatically using [addon-smart-knobs](https://github.com/storybookjs/addon-smart-knobs). For example:
+
+```ts
+export function MyComponent(props: { myUnion: true | "a" | 1 }) {}
+
+// The type of `myUnion` with `shouldExtractLiteralValuesFromEnum: false`:
+{ name: 'true | "a" | 1' }
+
+// With `shouldExtractLiteralValuesFromEnum: true`:
+{
+  name: 'enum',
+  raw: 'true | "a" | 1',
+  value: [
+    { value: 'true' },
+    { value: '"a"' },
+    { value: '1' }
+  ]
+}
+```
 
 ### `shouldExtractValuesFromUnion`: boolean
 
-If set to true, every unions will be converted to docgen enum format.
+If set to true, all unions will be converted to docgen enum format.
 
 ### `skipChildrenPropWithoutDoc`: boolean (default: `true`)
 

--- a/src/__tests__/data/ExtractLiteralValuesFromUnion.tsx
+++ b/src/__tests__/data/ExtractLiteralValuesFromUnion.tsx
@@ -8,7 +8,7 @@ interface ExtractLiteralValuesFromUnionProps {
   /** sampleComplexUnion description */
   sampleComplexUnion: number | 'string1' | 'string2';
   /** sampleMixedUnion description */
-  sampleMixedUnion: 1 | 2 | 'string1' | 'string2';
+  sampleMixedUnion: false | 1 | 2 | 'string1' | 'string2';
 }
 
 export const Stateless: React.StatelessComponent<ExtractLiteralValuesFromUnionProps> = props => (

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1272,19 +1272,20 @@ describe('parser', () => {
           false,
           null,
           {
-            shouldExtractValuesFromUnion: true
+            shouldExtractLiteralValuesFromEnum: true
           }
         );
       });
-      it('extracts numbers and strings from a mixed union', () => {
+      it('extracts literal values from a mixed union', () => {
         check(
           'ExtractLiteralValuesFromUnion',
           {
             ExtractLiteralValuesFromUnion: {
               sampleMixedUnion: {
-                raw: '"string1" | "string2" | 1 | 2',
+                raw: 'false | "string1" | "string2" | 1 | 2',
                 type: 'enum',
                 value: [
+                  { value: 'false' },
                   { value: '"string1"' },
                   { value: '"string2"' },
                   { value: '1' },
@@ -1296,7 +1297,7 @@ describe('parser', () => {
           false,
           null,
           {
-            shouldExtractValuesFromUnion: true
+            shouldExtractLiteralValuesFromEnum: true
           }
         );
       });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -569,7 +569,17 @@ export class Parser {
               (ts.TypeFlags.StringLiteral |
                 ts.TypeFlags.NumberLiteral |
                 ts.TypeFlags.EnumLiteral |
+                ts.TypeFlags.BooleanLiteral |
                 ts.TypeFlags.Undefined)
+          ) &&
+          // `boolean` is parsed identically to `true | false`, so we make sure one of the types
+          // is something other than boolean or undefined before considering it an enum/union
+          propType.types.some(
+            type =>
+              !(
+                type.getFlags() &
+                (ts.TypeFlags.BooleanLiteral | ts.TypeFlags.Undefined)
+              )
           ))
       ) {
         return {


### PR DESCRIPTION
Currently, simple unions are not converted to docgen enums if they contain boolean literals. I ran into this when documenting a component with this shape:

```tsx
function MyComponent(props: {
  property: "value" | "value2" | false;
}) {}
```

### Notes
While updating the test "extracts numbers and strings from a mixed union" to "extracts literal values from a mixed union", I changed the options passed in it and the previous test, "extracts numbers from a union". Previously, they had `shouldExtractValuesFromUnion` instead of `shouldExtractLiteralValuesFromEnum`, which seem more relevant. Since `shouldExtractValuesFromUnion` is essentially the same as `shouldExtractLiteralValuesFromEnum` with fewer safeguards, and both tests continued to pass even before I made any other changes, this version seems more correct.

### Caveat
One slight caveat to this is that TypeScript seems to not distinguish between `boolean` and `true | false`, so a union including `boolean` rather than a boolean _literal_ will have `true` and `false` literals extracted, e.g.:

```tsx
// for this component:
function A(props: { foo: boolean | "a" }) {}

// the extracted type of `foo` will be:
{
  name: 'enum',
  raw: 'true | false | "a"',
  value: [
    { value: 'true' },
    { value: 'false' },
    { value: '"a"' }
  ]
}
```

The available options being `boolean` and `"a"` might be a bit more intuitive. However, I think this is actually a positive, at least for the Storybook control use-case mentioned in the readme: since `boolean` is not a literal, Storybook controls shouldn't use it as a value, however `true` and `false` are safe. I also added a check to make sure we don't treat a plain `boolean` as an enum.