### PR TITLE
chore: add an ability to extend component types by option field

### DIFF
--- a/src/__tests__/data/Issue320.tsx
+++ b/src/__tests__/data/Issue320.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+/**
+ * that example is copied from MaterialUI
+ * some components return not expected interface/type
+ * like Avatar, IconButton, etc.
+ */
+
+export interface OverridableTypeMap {
+  props: {};
+}
+
+interface Props {
+  text: string;
+}
+
+export interface OverridableComponent<M extends OverridableTypeMap> {
+  (props: M['props'] & { color?: string }): JSX.Element;
+  (props: M): JSX.Element;
+}
+
+export type ComponentTypeMap = {
+  props: {
+    text: string;
+  };
+};
+
+const Component: OverridableComponent<ComponentTypeMap> = () => ({
+  text
+}: Props) => {
+  return <div>{text}</div>;
+};
+
+export default Component;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1567,5 +1567,27 @@ describe('parser', () => {
         ''
       );
     });
+
+    it('should return prop types for custom component type', () => {
+      check(
+        'Issue320',
+        {
+          Issue320: {
+            color: {
+              type: 'string',
+              required: false,
+              description: ''
+            },
+            text: { type: 'string', required: true, description: '' }
+          }
+        },
+        true,
+        null,
+        {
+          customComponentTypes: ['OverridableComponent'],
+          savePropValueAsString: true
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
Issue/task https://github.com/styleguidist/react-docgen-typescript/issues/320

Changes let developers specify custom component types (like StyledComponent or ForwardRefExoticComponent)