### PR TITLE
Parse displayName for stateless components whose name dont match the file name

### DIFF
--- a/src/__tests__/data/StatelessDisplayNameDefaultExportDifferentFilename.tsx
+++ b/src/__tests__/data/StatelessDisplayNameDefaultExportDifferentFilename.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export interface StatelessProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** Stateless description */
+const Stateless: React.SFC<StatelessProps> = props => (
+  <div>My Property = {props.myProp}</div>
+);
+
+Stateless.displayName = 'ThisNameIsNotTheSameAsThisFilename';
+
+export default Stateless;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -931,6 +931,13 @@ describe('parser', () => {
       assert.equal(parsed.displayName, 'StatelessDisplayNameDefaultExport');
     });
 
+    it("should be taken from stateless component `displayName` property (using default export) even if file name doesn't match", () => {
+      const [parsed] = parse(
+        fixturePath('StatelessDisplayNameDefaultExportDifferentFilename')
+      );
+      assert.equal(parsed.displayName, 'ThisNameIsNotTheSameAsThisFilename');
+    });
+
     it('should be taken from stateful component `displayName` property (using default export)', () => {
       const [parsed] = parse(fixturePath('StatefulDisplayNameDefaultExport'));
       assert.equal(parsed.displayName, 'StatefulDisplayNameDefaultExport');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1168,15 +1168,6 @@ function getTextValueOfFunctionProperty(
       );
     })
     .filter(statement => {
-      const expr = (statement as ts.ExpressionStatement)
-        .expression as ts.BinaryExpression;
-
-      return (
-        ((expr.left as ts.PropertyAccessExpression).expression as ts.Identifier)
-          .escapedText === exp.getName()
-      );
-    })
-    .filter(statement => {
       return ts.isStringLiteral(
         ((statement as ts.ExpressionStatement)
           .expression as ts.BinaryExpression).right


### PR DESCRIPTION
I noticed that when stateless components are declared as `const Component = (props) => ...` their `displayName` property didn't get parsed correctly when the component is a default export.

This is my first PR to this repo so I hope I did everything right! Let me know if this can be improved in any way. I'm not too hot on the test fixture filename or `displayName` so I'm open to suggestions, I just picked a name that would stress the difference between the file's name and the component's `displayName`.

Thanks for reviewing!