### PR TITLE
hotfix: parse tag text

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -773,7 +773,7 @@ export class Parser {
     const tagMap: StringIndexedObject<string> = {};
 
     tags.forEach(tag => {
-      const trimmedText = ts.displayPartsToString(tag.text).trim();
+      const trimmedText = (tag.text || '').trim();
       const currentValue = tagMap[tag.name];
       tagMap[tag.name] = currentValue
         ? currentValue + '\n' + trimmedText


### PR DESCRIPTION
when i used react-docgen-typescript@2.0.0, i can't get the right value of `@default` tag in my interface comment like this:

```
export interface ComponentProps {
  /**
   * Component Theme
   * @default light
   */
  theme?: 'light' | 'dark' | 'gray';
}
```

I found the [commit](https://github.com/styleguidist/react-docgen-typescript/commit/417d45c74f9cce9903ef3c4e2f9498acfd9a1c38#diff-abe2818e9c29aadf84401cb7ef8286c7cbce9253eba09f6fa52e22ca4e57b17eL761) who changed `tag.text` to `ts.displayPartsToString` introduced this problem.

`ts.displayPartsToString` in typescript@4.4.0 is:
```
export function displayPartsToString(displayParts: SymbolDisplayPart[] | undefined) {
    if (displayParts) {
        return map(displayParts, displayPart => displayPart.text).join("");
    }

    return "";
}
```

we can't get the correct value if we pass  `tag.text` (is a string) into the `displayPartsToString`.

