### PR TITLE
Follow symbol aliases also for named exports

### DIFF
--- a/src/__tests__/data/OnlyDefaultExportUnionAsExport.tsx
+++ b/src/__tests__/data/OnlyDefaultExportUnionAsExport.tsx
@@ -1,0 +1,1 @@
+export { default as OnlyDefaultExportUnion } from './OnlyDefaultExportUnion';

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -726,6 +726,19 @@ describe('parser', () => {
     });
   });
 
+  it('should parse components with unioned types when re-exported as named export', () => {
+    check(
+      'OnlyDefaultExportUnionAsExport',
+      {
+        OnlyDefaultExportUnion: {
+          content: { description: 'The content', type: 'string' }
+        }
+      },
+      true,
+      'OnlyDefaultExportUnion description'
+    );
+  });
+
   it('should parse jsdocs with the @default tag and no description', () => {
     check('StatelessWithDefaultOnlyJsDoc', {
       StatelessWithDefaultOnlyJsDoc: {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -293,11 +293,7 @@ export class Parser {
     const filePath = source.fileName;
 
     if (!rootExp.valueDeclaration) {
-      if (
-        originalName === 'default' &&
-        !typeSymbol &&
-        (rootExp.flags & ts.SymbolFlags.Alias) !== 0
-      ) {
+      if (!typeSymbol && (rootExp.flags & ts.SymbolFlags.Alias) !== 0) {
         commentSource = this.checker.getAliasedSymbol(commentSource);
       } else if (!typeSymbol) {
         return null;


### PR DESCRIPTION
Currently the aliased symbol is looked up for default exports, but should also work for named exports.