### PR TITLE
feat: Provide raw expression as part of parser output

### DIFF
--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -977,55 +977,6 @@ describe('parser', () => {
     });
   });
 
-  describe('expression name', () => {
-    it('should match the stateless component identifier (using named export)', () => {
-      const [parsed] = parse(fixturePath('StatelessDisplayName'));
-      assert.equal(parsed.expression.getName(), 'Stateless');
-    });
-
-    it('should match the stateful component identifier (using named export)', () => {
-      const [parsed] = parse(fixturePath('StatefulDisplayName'));
-      assert.equal(parsed.expression.getName(), 'Stateful');
-    });
-
-    it('should match the stateless component identifier (using default export)', () => {
-      const [parsed] = parse(fixturePath('StatelessDisplayNameDefaultExport'));
-      assert.equal(parsed.expression.getName(), 'default');
-    });
-
-    it("should be taken from stateless component identifier (using default export) even if file name doesn't match", () => {
-      const [parsed] = parse(
-        fixturePath('StatelessDisplayNameDefaultExportDifferentFilename')
-      );
-      assert.equal(parsed.expression.getName(), 'default');
-    });
-
-    it('should be taken from stateful component identifier (using default export)', () => {
-      const [parsed] = parse(fixturePath('StatefulDisplayNameDefaultExport'));
-      assert.equal(parsed.expression.getName(), 'default');
-    });
-
-    it('should be taken from the wrapped component identifier when default export is an HOC', () => {
-      const [parsed] = parse(fixturePath('StatelessDisplayNameHOC'));
-      assert.equal(parsed.expression.getName(), 'Stateless');
-    });
-
-    it('should be taken from the wrapped component identifier when default export is an HOC', () => {
-      const [parsed] = parse(fixturePath('StatefulDisplayNameHOC'));
-      assert.equal(parsed.expression.getName(), 'Stateful');
-    });
-
-    it('should be taken from stateless component identifier if file name is "index"', () => {
-      const [parsed] = parse(fixturePath('StatelessDisplayNameFolder/index'));
-      assert.equal(parsed.expression.getName(), 'default');
-    });
-
-    it('should be taken from stateful component identifier if file name is "index"', () => {
-      const [parsed] = parse(fixturePath('StatefulDisplayNameFolder/index'));
-      assert.equal(parsed.expression.getName(), 'default');
-    });
-  });
-
   describe('Parser options', () => {
     describe('Property filtering', () => {
       describe('children', () => {
@@ -1541,6 +1492,20 @@ describe('parser', () => {
           null,
           { shouldIncludePropTagMap: true }
         );
+      });
+    });
+
+    describe('shouldIncludeExpression', () => {
+      it('should be disabled by default', () => {
+        const [parsed] = parse(fixturePath('StatelessDisplayName'));
+        assert.equal(parsed.expression, undefined);
+      });
+
+      it('should cause the parser to return the component expression when set to true', () => {
+        const [parsed] = parse(fixturePath('StatelessDisplayName'), {
+          shouldIncludeExpression: true
+        });
+        assert.equal(parsed.expression!.name, 'Stateless');
       });
     });
   });

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -977,6 +977,55 @@ describe('parser', () => {
     });
   });
 
+  describe('expression name', () => {
+    it('should match the stateless component identifier (using named export)', () => {
+      const [parsed] = parse(fixturePath('StatelessDisplayName'));
+      assert.equal(parsed.expression.getName(), 'Stateless');
+    });
+
+    it('should match the stateful component identifier (using named export)', () => {
+      const [parsed] = parse(fixturePath('StatefulDisplayName'));
+      assert.equal(parsed.expression.getName(), 'Stateful');
+    });
+
+    it('should match the stateless component identifier (using default export)', () => {
+      const [parsed] = parse(fixturePath('StatelessDisplayNameDefaultExport'));
+      assert.equal(parsed.expression.getName(), 'default');
+    });
+
+    it("should be taken from stateless component identifier (using default export) even if file name doesn't match", () => {
+      const [parsed] = parse(
+        fixturePath('StatelessDisplayNameDefaultExportDifferentFilename')
+      );
+      assert.equal(parsed.expression.getName(), 'default');
+    });
+
+    it('should be taken from stateful component identifier (using default export)', () => {
+      const [parsed] = parse(fixturePath('StatefulDisplayNameDefaultExport'));
+      assert.equal(parsed.expression.getName(), 'default');
+    });
+
+    it('should be taken from the wrapped component identifier when default export is an HOC', () => {
+      const [parsed] = parse(fixturePath('StatelessDisplayNameHOC'));
+      assert.equal(parsed.expression.getName(), 'Stateless');
+    });
+
+    it('should be taken from the wrapped component identifier when default export is an HOC', () => {
+      const [parsed] = parse(fixturePath('StatefulDisplayNameHOC'));
+      assert.equal(parsed.expression.getName(), 'Stateful');
+    });
+
+    it('should be taken from stateless component identifier if file name is "index"', () => {
+      const [parsed] = parse(fixturePath('StatelessDisplayNameFolder/index'));
+      assert.equal(parsed.expression.getName(), 'default');
+    });
+
+    it('should be taken from stateful component identifier if file name is "index"', () => {
+      const [parsed] = parse(fixturePath('StatefulDisplayNameFolder/index'));
+      assert.equal(parsed.expression.getName(), 'default');
+    });
+  });
+
   describe('Parser options', () => {
     describe('Property filtering', () => {
       describe('children', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,6 +14,7 @@ export interface StringIndexedObject<T> {
 }
 
 export interface ComponentDoc {
+  expression: ts.Symbol;
   displayName: string;
   filePath: string;
   description: string;
@@ -373,6 +374,7 @@ export class Parser {
         description,
         displayName,
         methods,
+        expression: rootExp,
         props
       };
     } else if (description && displayName) {
@@ -382,6 +384,7 @@ export class Parser {
         description,
         displayName,
         methods,
+        expression: rootExp,
         props: {}
       };
     }


### PR DESCRIPTION
This is re: https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/51 and https://github.com/storybookjs/storybook/issues/15401 cc @hipstersmoothie @leepowelldev

**tl;dr** This PR would allow consumers who parse components with `react-docgen-typescript` to access the expression for that component.

## Use case

In Storybook, a component's prop table will break if you set the component's `displayName` to a value that differs from its identifier. For example, let's say that you define a component like this:

```ts
export const Button = (props: ButtonComponentProps) => (
  <button>{props.text}</button>
);

Button.displayName = "MyButtonDisplayName";
```

Then [`react-docgen-typescript-plugin`](https://github.com/hipstersmoothie/react-docgen-typescript-plugin) will append code to that module like this:

```ts
try {
    // @ts-ignore
    MyButtonDisplayName.displayName = "MyButtonDisplayName";
    // @ts-ignore
    MyButtonDisplayName.__docgenInfo = { "description": "", "displayName": "MyButtonDisplayName", "props": { "text": { "defaultValue": null, "description": "", "name": "text", "required": true, "type": { "name": "string" } } } };
}
catch (__react_docgen_typescript_loader_error) { }
```

That code will be a no-op, because `MyButtonDisplayName` is an invalid reference.

Why does `react-docgen-typescript-plugin` behave this way? Because the `react-docgen-typescript` parser doesn't return any way of obtaining the component's identifier other than `displayName`.

If the parser returned the component `expression`, then consumers like `react-docgen-typescript-plugin` could use `expression.getName()` instead of `displayName` to correctly handle cases where `displayName` is a different value.

---

Note that I opted to return the `expression` object here, rather than just the result of `expression.getName()`, because it might help to address another case: unnamed default exports. `react-docgen-typescript-plugin` fails for component declarations of the form `export default function() { ... }`, since there's no identifier to reference the component in that case. But using the expression, it might be able to inject one—that is, it could convert the component declaration to one of the form `export default function SomeGeneratedName() { ... }`, making it referencable.