### PR TITLE
Fix tags type

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,7 +19,7 @@ export interface ComponentDoc {
   description: string;
   props: Props;
   methods: Method[];
-  tags?: {};
+  tags?: StringIndexedObject<string>;
 }
 
 export interface Props extends StringIndexedObject<PropItem> {}


### PR DESCRIPTION
The generated ComponentDoc objects do have a filled out `tags` map, so
this patch updates the type.

However, it does not update the `PropItem` type as those tags appear to
always be empty (with tags ending up in the description).