### PR TITLE
feat: Export raw expression when shouldIncludeExpression is set

### DIFF
--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1513,7 +1513,7 @@ describe('parser', () => {
       it('should be disabled by default', () => {
         const [parsed] = parse(fixturePath('StatelessDisplayName'));
         assert.equal(parsed.expression, undefined);
-        assert.equal(parsed.expression, parsed.rawExpression);
+        assert.equal(parsed.expression, parsed.rootExpression);
       });
 
       it('should cause the parser to return the component expression when set to true', () => {
@@ -1521,10 +1521,10 @@ describe('parser', () => {
           shouldIncludeExpression: true
         });
         assert.equal(parsed.expression!.name, 'Stateless');
-        assert.equal(parsed.expression, parsed.rawExpression);
+        assert.equal(parsed.expression, parsed.rootExpression);
       });
 
-      it('should cause the parser to return the raw expression when set to true', () => {
+      it('should cause the parser to return the root expression when set to true', () => {
         const [parsed] = parse(
           fixturePath('FunctionDeclarationAsDefaultExportWithMemo'),
           {
@@ -1532,7 +1532,7 @@ describe('parser', () => {
           }
         );
         assert.equal(parsed.expression!.name, 'Jumbotron');
-        assert.equal(parsed.rawExpression!.name, 'default');
+        assert.equal(parsed.rootExpression!.name, 'default');
       });
     });
   });

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1513,6 +1513,7 @@ describe('parser', () => {
       it('should be disabled by default', () => {
         const [parsed] = parse(fixturePath('StatelessDisplayName'));
         assert.equal(parsed.expression, undefined);
+        assert.equal(parsed.expression, parsed.rawExpression);
       });
 
       it('should cause the parser to return the component expression when set to true', () => {
@@ -1520,6 +1521,18 @@ describe('parser', () => {
           shouldIncludeExpression: true
         });
         assert.equal(parsed.expression!.name, 'Stateless');
+        assert.equal(parsed.expression, parsed.rawExpression);
+      });
+
+      it('should cause the parser to return the raw expression when set to true', () => {
+        const [parsed] = parse(
+          fixturePath('FunctionDeclarationAsDefaultExportWithMemo'),
+          {
+            shouldIncludeExpression: true
+          }
+        );
+        assert.equal(parsed.expression!.name, 'Jumbotron');
+        assert.equal(parsed.rawExpression!.name, 'default');
       });
     });
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,7 +15,7 @@ export interface StringIndexedObject<T> {
 
 export interface ComponentDoc {
   expression?: ts.Symbol;
-  rawExpression?: ts.Symbol;
+  rootExpression?: ts.Symbol;
   displayName: string;
   filePath: string;
   description: string;
@@ -396,7 +396,7 @@ export class Parser {
 
     if (result !== null && this.shouldIncludeExpression) {
       result.expression = rootExp;
-      result.rawExpression = exp;
+      result.rootExpression = exp;
     }
 
     return result;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,6 +15,7 @@ export interface StringIndexedObject<T> {
 
 export interface ComponentDoc {
   expression?: ts.Symbol;
+  rawExpression?: ts.Symbol;
   displayName: string;
   filePath: string;
   description: string;
@@ -395,6 +396,7 @@ export class Parser {
 
     if (result !== null && this.shouldIncludeExpression) {
       result.expression = rootExp;
+      result.rawExpression = exp;
     }
 
     return result;


### PR DESCRIPTION
Resolves #432 cc @joshwooding

This PR adds a property called `rawExpression` to the parsed object when `shouldIncludeExpression` is set, in addition to the existing `expression` property. The two are identical in many cases, but diverge when the exported component has a wrapper such as `React.memo`. Example from the test cases:

```ts
// parsed.expression
function Jumbotron(props: JumbotronProps) {
  return <div>Test</div>;
}

// parsed.rawExpression
export default React.memo(Jumbotron);
```

Exporting both will allow developers to extract additional information from the raw expression when necessary.