### PR TITLE
Resolve issue with first displayName always being used

### DIFF
--- a/src/__tests__/data/StatelessDisplayNameMultipleDisplayNames.tsx
+++ b/src/__tests__/data/StatelessDisplayNameMultipleDisplayNames.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => <button {...props} ref={ref} type="button" />
+);
+
+Button.displayName = 'First';
+
+export const SubmitButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => <button {...props} ref={ref} type="submit" />
+);
+
+SubmitButton.displayName = 'Second';
+
+export const ResetButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => <button {...props} ref={ref} type="reset" />
+);
+
+ResetButton.displayName = 'Third';

--- a/src/__tests__/data/StatelessDisplayNameMultipleFnsOneDisplayName.tsx
+++ b/src/__tests__/data/StatelessDisplayNameMultipleFnsOneDisplayName.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => <button {...props} ref={ref} type="button" />
+);
+
+Button.displayName = 'First';
+
+export const someSeparateFunction = () => {};

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -989,6 +989,32 @@ describe('parser', () => {
       const [parsed] = parse(fixturePath('StatefulDisplayNameFolder/index'));
       assert.equal(parsed.displayName, 'StatefulDisplayNameFolder');
     });
+
+    it('should get all displayNames from single file when multiple functions have the property defined', () => {
+      const [parsed1, parsed2, parsed3] = parse(
+        fixturePath('StatelessDisplayNameMultipleDisplayNames')
+      );
+
+      // parsed1.displayName === 'Button'?
+      // parsed1.displayName === 'SubmitButton'?
+      // parsed1.displayName === 'ResetButton'?
+
+      assert.equal(parsed1.displayName, 'First');
+      assert.equal(parsed2.displayName, 'Second');
+      assert.equal(parsed3.displayName, 'Third');
+    });
+
+    it('should get all displayNames from single file when multiple functions have the property defined', () => {
+      const [parsed1, parsed2] = parse(
+        fixturePath('StatelessDisplayNameMultipleFnsOneDisplayName')
+      );
+
+      // parsed1.displayName === 'Button'?
+      // parsed2 is `undefined`?
+
+      assert.equal(parsed1.displayName, 'First');
+      assert.equal(parsed2.displayName, 'someSeparateFunction');
+    });
   });
 
   describe('Parser options', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1198,11 +1198,26 @@ function getTextValueOfFunctionProperty(
     .filter(statement => {
       const expr = (statement as ts.ExpressionStatement)
         .expression as ts.BinaryExpression;
+
+      /**
+       * Ensure the .displayName is for the currently processing function.
+       *
+       * This avoids the following situations:
+       *
+       *  - A file has multiple functions, one has `.displayName`, and all
+       *    functions ends up with that same `.displayName` value.
+       *
+       *  - A file has multiple functions, each with a different
+       *    `.displayName`, but the first is applied to all of them.
+       */
+      const flowNodeNameEscapedText = (statement as any)?.flowNode?.node?.name
+        ?.escapedText as false | ts.__String | undefined;
+
       return (
         expr.left &&
         (expr.left as ts.PropertyAccessExpression).name &&
         (expr.left as ts.PropertyAccessExpression).name.escapedText ===
-          propertyName
+          (propertyName && flowNodeNameEscapedText === exp.escapedName)
       );
     })
     .filter(statement => {


### PR DESCRIPTION
Fixes: #395
Fixes: #437

I basically did the fix outlined in #437 by @jesstelford and added some tests.

The tests all seem to fail 😬 

Would love to fix the `displayName` issue, but I'm not sure how to proceed here! Just wanted to put a foot forward. I also would like to add a test specifically about the issue outlined in #395 where the first displayName is applied, even if the function it's applied to is not exported.