### PR TITLE
Add support for @defaultValue TSDoc tag

### DIFF
--- a/src/__tests__/data/StatelessWithDefaultValueAndDescriptionJsDoc.tsx
+++ b/src/__tests__/data/StatelessWithDefaultValueAndDescriptionJsDoc.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface StatelessWithDefaultValueAndDescriptionJsDocProps {
+  /**
+   * The content
+   *
+   * @defaultValue hello
+   */
+  myProp: string;
+}
+/** StatelessWithDefaultValueAndDescriptionJsDoc description */
+export const StatelessWithDefaultValueAndDescriptionJsDoc: React.StatelessComponent<StatelessWithDefaultValueAndDescriptionJsDocProps> = props => (
+  <div>My Property = {props.myProp}</div>
+);

--- a/src/__tests__/data/StatelessWithDefaultValueOnlyJsDoc.tsx
+++ b/src/__tests__/data/StatelessWithDefaultValueOnlyJsDoc.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export interface StatelessWithDefaultValueOnlyJsDocProps {
+  /**
+   * @defaultValue hello
+   */
+  myProp: string;
+}
+/** StatelessWithDefaultValueOnlyJsDoc description */
+export const StatelessWithDefaultValueOnlyJsDoc: React.StatelessComponent<StatelessWithDefaultValueOnlyJsDocProps> = props => (
+  <div>My Property = {props.myProp}</div>
+);

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -747,6 +747,26 @@ describe('parser', () => {
     });
   });
 
+  it('should parse jsdocs with the @defaultValue tag and no description', () => {
+    check('StatelessWithDefaultValueOnlyJsDoc', {
+      StatelessWithDefaultValueOnlyJsDoc: {
+        myProp: { defaultValue: 'hello', description: '', type: 'string' }
+      }
+    });
+  });
+
+  it('should parse jsdocs with the @defaultValue tag and description', () => {
+    check('StatelessWithDefaultValueAndDescriptionJsDoc', {
+      StatelessWithDefaultValueAndDescriptionJsDoc: {
+        myProp: {
+          defaultValue: 'hello',
+          description: 'The content',
+          type: 'string'
+        }
+      }
+    });
+  });
+
   it('should parse functional component component defined as function', () => {
     check('FunctionDeclaration', {
       Jumbotron: {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -704,6 +704,8 @@ export class Parser {
 
       if (hasCodeBasedDefault) {
         defaultValue = { value: defaultProps[propName] };
+      } else if (jsDocComment.tags.defaultValue) {
+        defaultValue = { value: jsDocComment.tags.defaultValue };
       } else if (jsDocComment.tags.default) {
         defaultValue = { value: jsDocComment.tags.default };
       }
@@ -751,7 +753,11 @@ export class Parser {
 
   public findDocComment(symbol: ts.Symbol): JSDoc {
     const comment = this.getFullJsDocComment(symbol);
-    if (comment.fullComment || comment.tags.default) {
+    if (
+      comment.fullComment ||
+      comment.tags.default ||
+      comment.tags.defaultValue
+    ) {
       return comment;
     }
 
@@ -799,7 +805,7 @@ export class Parser {
         ? currentValue + '\n' + trimmedText
         : trimmedText;
 
-      if (['default', 'type'].indexOf(tag.name) < 0) {
+      if (['default', 'type', 'defaultValue'].indexOf(tag.name) < 0) {
         tagComments.push(formatTag(tag));
       }
     });


### PR DESCRIPTION
This adds support for the **`@defaultValue`** tag from the **TSDoc** specification. The existence of both specs can be pretty confusing because there's quite a bit of overlap, but I think ultimately what we're writing in `.ts` files _is_ **TSDoc** as it doesn't include the type information like **JSDoc** does. I kept support for the **@default** tag both for backward compatibility and because TypeScript does support actual **JSDoc** in `.js` files, though I'm not sure whether this tool actually does support that case.

For reference:
- https://tsdoc.org/pages/tags/defaultvalue/
- https://github.com/microsoft/tsdoc/issues/27
- https://jsdoc.app/tags-default.html

I'm happy to address any feedback and thanks for this wonderful tool!
