### PR TITLE
Handle multiple file extensions in `getDefaultExportForFile`

### DIFF
--- a/src/__tests__/data/StatelessDisplayNameFolder/Stateless.d.ts
+++ b/src/__tests__/data/StatelessDisplayNameFolder/Stateless.d.ts
@@ -1,0 +1,7 @@
+export interface FooProps {
+  foo?: string;
+}
+
+declare const Foo: React.FC<FooProps>;
+
+export default Foo;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -45,6 +45,19 @@ describe('parser', () => {
     });
   });
 
+  it('should parse simple typescript definition file with default export', () => {
+    check(
+      'StatelessDisplayNameFolder/Stateless.d.ts',
+      {
+        Stateless: {
+          foo: { description: '', type: 'string', required: false }
+        }
+      },
+      true,
+      ''
+    );
+  });
+
   describe('file path', () => {
     it('should return the correct filepath for a parsed component', () => {
       const results = parse([fixturePath('FilePathCheck')]);

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -40,7 +40,7 @@ export function fixturePath(componentName: string) {
     'src',
     '__tests__',
     'data',
-    `${componentName}.tsx`
+    `${componentName}${componentName.includes('.ts') ? '' : '.tsx'}`
   ); // it's running in ./temp
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -359,14 +359,12 @@ export class Parser {
 
     let result: ComponentDoc | null = null;
     if (propsType) {
-      let commentDeclaration =
-        commentSource.valueDeclaration ??
-        commentSource.declarations?.[0] ??
-        rootExp.valueDeclaration ??
-        commentSource.declarations?.[0];
+      if (!commentSource.valueDeclaration) {
+        return null;
+      }
       const defaultProps = this.extractDefaultPropsFromComponent(
         commentSource,
-        commentDeclaration?.getSourceFile()
+        commentSource.valueDeclaration.getSourceFile()
       );
       const props = this.getPropsInfo(propsType, defaultProps);
 
@@ -842,9 +840,8 @@ export class Parser {
 
   public extractDefaultPropsFromComponent(
     symbol: ts.Symbol,
-    source?: ts.SourceFile
+    source: ts.SourceFile
   ) {
-    if (source == null) return {};
     let possibleStatements = [
       ...source.statements
         // ensure that name property is available

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -359,12 +359,14 @@ export class Parser {
 
     let result: ComponentDoc | null = null;
     if (propsType) {
-      if (!commentSource.valueDeclaration) {
-        return null;
-      }
+      let commentDeclaration =
+        commentSource.valueDeclaration ??
+        commentSource.declarations?.[0] ??
+        rootExp.valueDeclaration ??
+        commentSource.declarations?.[0];
       const defaultProps = this.extractDefaultPropsFromComponent(
         commentSource,
-        commentSource.valueDeclaration.getSourceFile()
+        commentDeclaration?.getSourceFile()
       );
       const props = this.getPropsInfo(propsType, defaultProps);
 
@@ -840,8 +842,9 @@ export class Parser {
 
   public extractDefaultPropsFromComponent(
     symbol: ts.Symbol,
-    source: ts.SourceFile
+    source?: ts.SourceFile
   ) {
+    if (source == null) return {};
     let possibleStatements = [
       ...source.statements
         // ensure that name property is available
@@ -1269,7 +1272,7 @@ function computeComponentName(
 
 // Default export for a file: named after file
 export function getDefaultExportForFile(source: ts.SourceFile) {
-  const name = path.basename(source.fileName, path.extname(source.fileName));
+  const name = path.basename(source.fileName).split('.')[0];
   const filename =
     name === 'index' ? path.basename(path.dirname(source.fileName)) : name;
 


### PR DESCRIPTION
There are cases that I have run into where the file being analyzed ends with `.d.ts` and that would inadvertently make the displayName end with an unintended `d`.
For example `List.d.ts` would become `Listd`.

This updates the logic in `getDefaultExportForFile` to split based on the first `.` instead of the last.