### PR TITLE
Prevent failing when there is no default props

### DIFF
--- a/src/__tests__/data/DefinitionFile.d.ts
+++ b/src/__tests__/data/DefinitionFile.d.ts
@@ -1,0 +1,14 @@
+declare const Bar: React.FC<{ bar: string }>;
+
+type FooBarProps = { foobar: string };
+
+declare const FooBar: React.FC<FooBarProps>;
+
+declare const Baz: (props: { baz: string }) => React.JSX.Element;
+
+declare const Buzz: {
+  (props: { buzz: string }): React.JSX.Element;
+  propTypes: any;
+};
+
+export { Bar, Baz, FooBar, Buzz };

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -121,7 +121,7 @@ describe('parser', () => {
 
   it('should parse typescript definition files', () => {
     check(
-      'DefinitionFile',
+      'DefinitionFile.d.ts',
       {
         Baz: {
           baz: { description: '', type: 'string', required: true }
@@ -137,9 +137,7 @@ describe('parser', () => {
         }
       },
       false,
-      '',
-      undefined,
-      '.d.ts'
+      ''
     );
   });
 

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -119,6 +119,30 @@ describe('parser', () => {
     });
   });
 
+  it('should parse typescript definition files', () => {
+    check(
+      'DefinitionFile',
+      {
+        Baz: {
+          baz: { description: '', type: 'string', required: true }
+        },
+        Bar: {
+          bar: { description: '', type: 'string', required: true }
+        },
+        FooBar: {
+          foobar: { description: '', type: 'string' }
+        },
+        Buzz: {
+          buzz: { description: '', type: 'string', required: true }
+        }
+      },
+      false,
+      '',
+      undefined,
+      '.d.ts'
+    );
+  });
+
   it('should parse simple react class component with picked properties', () => {
     check('ColumnWithPick', {
       Column: {

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -32,7 +32,7 @@ export interface ExpectedProp {
   };
 }
 
-export function fixturePath(componentName: string, ext?: string) {
+export function fixturePath(componentName: string) {
   return path.join(
     __dirname,
     '..',
@@ -40,7 +40,7 @@ export function fixturePath(componentName: string, ext?: string) {
     'src',
     '__tests__',
     'data',
-    `${componentName}${ext ?? '.tsx'}`
+    `${componentName}${componentName.includes('.ts') ? '' : '.tsx'}`
   ); // it's running in ./temp
 }
 
@@ -49,10 +49,9 @@ export function check(
   expected: ExpectedComponents,
   exactProperties: boolean = true,
   description?: string | null,
-  parserOpts?: ParserOptions,
-  extension?: string
+  parserOpts?: ParserOptions
 ) {
-  const result = parse(fixturePath(componentName, extension), parserOpts);
+  const result = parse(fixturePath(componentName), parserOpts);
   checkComponent(result, expected, exactProperties, description);
 }
 

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -32,7 +32,7 @@ export interface ExpectedProp {
   };
 }
 
-export function fixturePath(componentName: string) {
+export function fixturePath(componentName: string, ext?: string) {
   return path.join(
     __dirname,
     '..',
@@ -40,7 +40,7 @@ export function fixturePath(componentName: string) {
     'src',
     '__tests__',
     'data',
-    `${componentName}.tsx`
+    `${componentName}${ext ?? '.tsx'}`
   ); // it's running in ./temp
 }
 
@@ -49,9 +49,10 @@ export function check(
   expected: ExpectedComponents,
   exactProperties: boolean = true,
   description?: string | null,
-  parserOpts?: ParserOptions
+  parserOpts?: ParserOptions,
+  extension?: string
 ) {
-  const result = parse(fixturePath(componentName), parserOpts);
+  const result = parse(fixturePath(componentName, extension), parserOpts);
   checkComponent(result, expected, exactProperties, description);
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -359,12 +359,11 @@ export class Parser {
 
     let result: ComponentDoc | null = null;
     if (propsType) {
-      if (!commentSource.valueDeclaration) {
-        return null;
-      }
+      let commentDeclaration =
+        commentSource.valueDeclaration ?? commentSource.declarations?.[0];
       const defaultProps = this.extractDefaultPropsFromComponent(
         commentSource,
-        commentSource.valueDeclaration.getSourceFile()
+        commentDeclaration?.getSourceFile()
       );
       const props = this.getPropsInfo(propsType, defaultProps);
 
@@ -840,8 +839,9 @@ export class Parser {
 
   public extractDefaultPropsFromComponent(
     symbol: ts.Symbol,
-    source: ts.SourceFile
+    source?: ts.SourceFile
   ) {
+    if (source == null) return {};
     let possibleStatements = [
       ...source.statements
         // ensure that name property is available

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -307,6 +307,7 @@ export class Parser {
 
         const defaultComponentTypes = [
           '__function',
+          '__type',
           'StatelessComponent',
           'Stateless',
           'StyledComponentClass',


### PR DESCRIPTION
A few components that I have run into while using this lib lack jsdoc comments or default props and currently it will just return null for the entire component. I belive that even without these that there is still value in the remaining information.

This PR simply allows the process to continue even when it is unable to extract any default props.