### PR TITLE
Perf improvements

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -225,6 +225,7 @@ export class Parser {
   private readonly savePropValueAsString: boolean;
   private readonly shouldIncludePropTagMap: boolean;
   private readonly shouldIncludeExpression: boolean;
+  private propertiesOfPropsCache: Map<string, PropItem> = new Map();
 
   constructor(program: ts.Program, opts: ParserOptions) {
     const {
@@ -701,60 +702,73 @@ export class Parser {
 
     propertiesOfProps.forEach(prop => {
       const propName = prop.getName();
-
-      // Find type of prop by looking in context of the props object itself.
-      const propType = this.checker.getTypeOfSymbolAtLocation(
-        prop,
-        propsObj.valueDeclaration!
-      );
-
-      const jsDocComment = this.findDocComment(prop);
-      const hasCodeBasedDefault = defaultProps[propName] !== undefined;
-
-      let defaultValue: { value: any } | null = null;
-
-      if (hasCodeBasedDefault) {
-        defaultValue = { value: defaultProps[propName] };
-      } else if (jsDocComment.tags.default) {
-        defaultValue = { value: jsDocComment.tags.default };
-      }
-
       const parent = getParentType(prop);
-      const parents = getDeclarations(prop);
-      const declarations = prop.declarations || [];
-      const baseProp = baseProps.find(p => p.getName() === propName);
+      const cacheKey = `${parent?.fileName}_${propName}`;
+      if (this.propertiesOfPropsCache.has(cacheKey)) {
+        result[propName] = this.propertiesOfPropsCache.get(
+          cacheKey
+        ) as PropItem;
+      } else {
+        // Find type of prop by looking in context of the props object itself.
+        const propType = this.checker.getTypeOfSymbolAtLocation(
+          prop,
+          propsObj.valueDeclaration!
+        );
 
-      const required =
-        !isOptional(prop) &&
-        !hasCodeBasedDefault &&
-        // If in a intersection or union check original declaration for "?"
-        // @ts-ignore
-        declarations.every(d => !d.questionToken) &&
-        (!baseProp || !isOptional(baseProp));
+        const jsDocComment = this.findDocComment(prop);
+        const hasCodeBasedDefault = defaultProps[propName] !== undefined;
 
-      const type = jsDocComment.tags.type
-        ? {
-            name: jsDocComment.tags.type
-          }
-        : this.getDocgenType(propType, required);
+        let defaultValue: { value: any } | null = null;
 
-      const propTags = this.shouldIncludePropTagMap
-        ? { tags: jsDocComment.tags }
-        : {};
-      const description = this.shouldIncludePropTagMap
-        ? jsDocComment.description.replace(/\r\n/g, '\n')
-        : jsDocComment.fullComment.replace(/\r\n/g, '\n');
+        if (hasCodeBasedDefault) {
+          defaultValue = { value: defaultProps[propName] };
+        } else if (jsDocComment.tags.default) {
+          defaultValue = { value: jsDocComment.tags.default };
+        }
 
-      result[propName] = {
-        defaultValue,
-        description: description,
-        name: propName,
-        parent,
-        declarations: parents,
-        required,
-        type,
-        ...propTags
-      };
+        const parents = getDeclarations(prop);
+        const declarations = prop.declarations || [];
+        const baseProp = baseProps.find(p => p.getName() === propName);
+
+        const required =
+          !isOptional(prop) &&
+          !hasCodeBasedDefault &&
+          // If in a intersection or union check original declaration for "?"
+          // @ts-ignore
+          declarations.every(d => !d.questionToken) &&
+          (!baseProp || !isOptional(baseProp));
+
+        const type = jsDocComment.tags.type
+          ? {
+              name: jsDocComment.tags.type
+            }
+          : this.getDocgenType(propType, required);
+
+        const propTags = this.shouldIncludePropTagMap
+          ? { tags: jsDocComment.tags }
+          : {};
+        const description = this.shouldIncludePropTagMap
+          ? jsDocComment.description.replace(/\r\n/g, '\n')
+          : jsDocComment.fullComment.replace(/\r\n/g, '\n');
+
+        const propItem: PropItem = {
+          defaultValue,
+          description: description,
+          name: propName,
+          parent,
+          declarations: parents,
+          required,
+          type,
+          ...propTags
+        };
+        if (parent?.fileName.includes('node_modules')) {
+          this.propertiesOfPropsCache.set(
+            `${parent.fileName}_${propName}`,
+            propItem
+          );
+        }
+        result[propName] = propItem;
+      }
     });
 
     return result;


### PR DESCRIPTION
Hello! Wondering if you would be open to making some perf improvements that I identified?

Background:
I've been trying to improve performance on a test suite using Storybook test runner on a Github Actions based CI. 

What I did:
I ran the test suite locally profiling with [Clinic flame](https://clinicjs.org/flame/). `react-docgen-typescript` had some very hot blocks in the flame graph that I was able to cool down substantially by caching the results of some functions.

For reference, here's the initial run showing `trimFileName.js` as the hottest block in the entire profile. (Updated image, I put the wrong one at first...)
<img width="1440" alt="Screenshot 2024-06-03 at 11 42 10" src="https://github.com/styleguidist/react-docgen-typescript/assets/4752047/1d181c14-6874-4fc2-bf5a-05435eddb762">

Results:
My 33 test suites containing 63 tests in total dropped from ~26 seconds to ~14 seconds. 

What I don't know:
If the cache keys I used are safe (could there be name collisions?). If you're interested in this kind of micro optimization for this repo.