### PR TITLE
Support extracting defaults from renamed destructuring

### DIFF
--- a/src/__tests__/data/StatelessWithDefaultProps.tsx
+++ b/src/__tests__/data/StatelessWithDefaultProps.tsx
@@ -28,6 +28,8 @@ export interface StatelessWithDefaultPropsProps {
   sampleUndefined?: any;
   /** sampleNumber description */
   sampleNumber?: number;
+  /** sampleRenamed description */
+  sampleRenamed?: string;
 }
 
 /** StatelessWithDefaultProps description */
@@ -44,5 +46,6 @@ StatelessWithDefaultProps.defaultProps = {
   sampleObject: { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
   sampleString: 'hello',
   sampleTrue: true,
-  sampleUndefined: undefined
+  sampleUndefined: undefined,
+  sampleRenamed: 'world'
 };

--- a/src/__tests__/data/StatelessWithDefaultPropsTypescript3.tsx
+++ b/src/__tests__/data/StatelessWithDefaultPropsTypescript3.tsx
@@ -28,6 +28,8 @@ export interface StatelessWithDefaultPropsProps {
   sampleUndefined: any;
   /** sampleNumber description */
   sampleNumber: number;
+  /** sampleRenamed description */
+  sampleRenamed?: string;
 }
 
 /** StatelessWithDefaultProps description */
@@ -44,5 +46,6 @@ StatelessWithDefaultProps.defaultProps = {
   sampleObject: { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
   sampleString: 'hello',
   sampleTrue: true,
-  sampleUndefined: undefined
+  sampleUndefined: undefined,
+  sampleRenamed: 'world'
 };

--- a/src/__tests__/data/StatelessWithDestructuredProps.tsx
+++ b/src/__tests__/data/StatelessWithDestructuredProps.tsx
@@ -28,6 +28,8 @@ export interface StatelessWithDefaultPropsProps {
   sampleUndefined?: any;
   /** sampleNumber description */
   sampleNumber?: number;
+  /** sampleRenamed description */
+  sampleRenamed?: string;
 }
 
 /** StatelessWithDefaultProps description */
@@ -40,7 +42,8 @@ export function StatelessWithDefaultProps({
   sampleObject = { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
   sampleString = 'hello',
   sampleTrue = true,
-  sampleUndefined
+  sampleUndefined,
+  sampleRenamed: renamedSample = 'world'
 }: StatelessWithDefaultPropsProps) {
   return <div>test</div>;
 }

--- a/src/__tests__/data/StatelessWithDestructuredPropsArrow.tsx
+++ b/src/__tests__/data/StatelessWithDestructuredPropsArrow.tsx
@@ -28,6 +28,8 @@ export interface StatelessWithDefaultPropsProps {
   sampleUndefined?: any;
   /** sampleNumber description */
   sampleNumber?: number;
+  /** sampleRenamed description */
+  sampleRenamed?: string;
 }
 
 /** StatelessWithDefaultProps description */
@@ -40,5 +42,6 @@ export const StatelessWithDefaultProps: React.StatelessComponent<StatelessWithDe
   sampleObject = { a: '1', b: 2, c: true, d: false, e: undefined, f: null, g: { a: '1' } },
   sampleString = 'hello',
   sampleTrue = true,
-  sampleUndefined
+  sampleUndefined,
+  sampleRenamed: renamedSample = 'world'
 }) => <div>test</div>;

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -672,6 +672,11 @@ describe('parser', () => {
           defaultValue: undefined,
           required: false,
           type: 'any'
+        },
+        sampleRenamed: {
+          defaultValue: 'world',
+          required: false,
+          type: 'string'
         }
       }
     };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1100,19 +1100,18 @@ export class Parser {
     properties: ts.NodeArray<ts.PropertyAssignment | ts.BindingElement>
   ): StringIndexedObject<string | boolean | number | null> {
     return properties.reduce((acc, property) => {
-      if (ts.isSpreadAssignment(property) || !property.name) {
+      const propertyName = getPropertyName(ts.isBindingElement(property) ? (property.propertyName || property.name) : property.name);
+      if (ts.isSpreadAssignment(property) || !propertyName) {
         return acc;
       }
 
       const literalValue = this.getLiteralValueFromPropertyAssignment(property);
-      const propertyName = getPropertyName(property.name);
 
       if (
         (typeof literalValue === 'string' ||
           typeof literalValue === 'number' ||
           typeof literalValue === 'boolean' ||
-          literalValue === null) &&
-        propertyName !== null
+          literalValue === null)
       ) {
         acc[propertyName] = literalValue;
       }


### PR DESCRIPTION
Re-opening #484 now there seems to be some activity on this repository

---

Where a property is renamed in a destructuring, react-docgen-typescript fails to detect the default as it currently reads it under the renamed name.

This PR fixes ensures we read the original name when detecting defaults from destructuring.