### PR TITLE
Set `esModuleInterop` as default config of `parse`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-docgen-typescript",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-docgen-typescript",
-      "version": "2.2.3",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.1.0",

--- a/src/__tests__/data/FunctionalComponentWithDefaultImportReact.tsx
+++ b/src/__tests__/data/FunctionalComponentWithDefaultImportReact.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface JumbotronProps {
+  /** prop1 description */
+  prop1: string;
+}
+
+/**
+ * Jumbotron description
+ */
+export const Jumbotron: React.FC<JumbotronProps> = props => {
+  return <div>Test</div>;
+};

--- a/src/__tests__/data/tsconfig.json
+++ b/src/__tests__/data/tsconfig.json
@@ -3,6 +3,7 @@
     /* Basic Options */
     "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "esModuleInterop": true,
     // "lib": [],                             /* Specify library files to be included in the compilation:  */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -776,6 +776,14 @@ describe('parser', () => {
     });
   });
 
+  it('should parse functional component declared as React.FC with default import from react', () => {
+    check('FunctionalComponentWithDefaultImportReact', {
+      Jumbotron: {
+        prop1: { type: 'string', required: true }
+      }
+    });
+  });
+
   it('should parse functional component defined as const with default value assignments in immediately destructured props', () => {
     check('FunctionalComponentWithDesctructuredProps', {
       FunctionalComponentWithDesctructuredProps: {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -113,7 +113,8 @@ export interface FileParser {
 export const defaultOptions: ts.CompilerOptions = {
   jsx: ts.JsxEmit.React,
   module: ts.ModuleKind.CommonJS,
-  target: ts.ScriptTarget.Latest
+  target: ts.ScriptTarget.Latest,
+  esModuleInterop: true
 };
 
 /**


### PR DESCRIPTION
The React namespace is exported as CommonJs. As stated in [TypeScript's Doc](https://www.typescriptlang.org/docs/handbook/modules/appendices/esm-cjs-interop.html#applications-with-commonjs-code-should-always-enable-esmoduleinterop), we should always enable `esModuleInterop`.

Without `esModuleInterop`, example below will produce incorrect result because `tsc` cannot handle the default import(such as `import React from 'react'`) of a CommonJs module correctly
```tsx
import React from 'react';

export interface JumbotronProps {
  /** prop1 description */
  prop1: string;
}

/**
 * Jumbotron description
 */
export const Jumbotron: React.FC<JumbotronProps> = props => {
  return <div>Test</div>;
};
```
Currently, we always import React using the default import syntax. Additionally, when using `tsc --init`, `esModuleInterop` is enabled by default. For these reasons, I believe it is time to set `esModuleInterop` as the default configuration for the `parse` API.
