### PR TITLE
fix parsing displayName for components defined using function expression

### DIFF
--- a/src/__tests__/data/MultipleAllWithDisplayName.tsx
+++ b/src/__tests__/data/MultipleAllWithDisplayName.tsx
@@ -3,10 +3,9 @@ import * as React from 'react';
 interface ButtonProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {}
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref) => <button {...props} ref={ref} type="button" />
-);
-
+export function Button(props: ButtonProps) {
+  return <button {...props} type="button" />;
+}
 Button.displayName = 'First';
 
 export const SubmitButton = React.forwardRef<HTMLButtonElement, ButtonProps>(

--- a/src/__tests__/data/StatelessDisplayNameFunctionExpression.tsx
+++ b/src/__tests__/data/StatelessDisplayNameFunctionExpression.tsx
@@ -1,0 +1,14 @@
+export interface StatelessFunctionExpressionProps {
+  /** myProp description */
+  myProp: string;
+}
+
+/** StatelessFunctionExpression description */
+export function StatelessFunctionExpression(
+  props: StatelessFunctionExpressionProps
+) {
+  return <div>My Property = {props.myProp}</div>;
+}
+
+StatelessFunctionExpression.displayName =
+  'StatelessDisplayNameFunctionExpression';

--- a/src/__tests__/parser.ts
+++ b/src/__tests__/parser.ts
@@ -1023,6 +1023,16 @@ describe('parser', () => {
       assert.equal(parsed.displayName, 'StatelessDisplayName');
     });
 
+    it('should be taken from stateless component `displayName` property (using named export and function expression)', () => {
+      const [parsed] = parse(
+        fixturePath('StatelessDisplayNameFunctionExpression')
+      );
+      assert.equal(
+        parsed.displayName,
+        'StatelessDisplayNameFunctionExpression'
+      );
+    });
+
     it('should be taken from stateful component `displayName` property (using named export)', () => {
       const [parsed] = parse(fixturePath('StatefulDisplayName'));
       assert.equal(parsed.displayName, 'StatefulDisplayName');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1340,7 +1340,8 @@ function getTextValueOfFunctionProperty(
         (expr.left as ts.PropertyAccessExpression).name &&
         (expr.left as ts.PropertyAccessExpression).name.escapedText ===
           propertyName &&
-        flowNodeNameEscapedText === exp.escapedName
+        (!flowNodeNameEscapedText ||
+          flowNodeNameEscapedText === exp.escapedName)
       );
     })
     .filter(statement => {


### PR DESCRIPTION
regression from #449

displayName for functions that are defined using function expression are no longer working correctly

not familiar enough with the codebase to figure out the actual problem - but for now this fix will work if you have only one function expression in the file - but will break in the edge case where you have more than one function expression components - probly related to how function components are resolved from some other change